### PR TITLE
Feat/scrum 59 bo admin auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### application.yml ###
 **/resources/application.yml
+
+### .env ###
+**/.env

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### .env ###
 **/.env
+
+### generated ###
+**/generated

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ out/
 
 ### application.yml ###
 **/resources/application.yml
+**/resources/application-dev.yml
+**/resources/application-local.yml
+**/resources/application-prod.yml
 
 ### .env ###
 **/.env

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,30 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Querydsl 설정 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl 설정부
+// 현재 위치: src/main/ -> 추후 변경 예정
+def generatedDir = "$projectDir/src/main/generated"
+
+sourceSets {
+    main.java.srcDirs += generatedDir
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file(generatedDir)
+}
+
+clean {
+    delete file(generatedDir)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // JWT Library
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
@@ -38,6 +44,9 @@ dependencies {
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  redis:
+    image: redis:7.2
+    container_name: redis
+    ports:
+      - "6379:6379"
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly yes

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.roome.admin.roomeadminbe.domain.admin.controller;
+
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.UpdateAdminInfoRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.UpdatePasswordRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.ReadAdminInfoResponse;
+import com.roome.admin.roomeadminbe.domain.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/admin/info")
+public class AdminController {
+
+	private final AdminService adminService;
+
+	@GetMapping
+	public ResponseEntity<ReadAdminInfoResponse> readInfo(@AuthenticationPrincipal UserDetails userDetails) {
+		ReadAdminInfoResponse readAdminInfo = adminService.readInfo(userDetails.getUsername());
+		return ResponseEntity.ok().body(readAdminInfo);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
@@ -29,4 +29,10 @@ public class AdminController {
 		adminService.updateInfo(userDetails.getUsername(), updateAdminInfoRequest);
 		return ResponseEntity.ok().build();
 	}
+
+	@PutMapping("/password")
+	public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated UpdatePasswordRequest updatePasswordRequest) {
+		adminService.updatePassword(userDetails.getUsername(), updatePasswordRequest);
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/controller/AdminController.java
@@ -23,4 +23,10 @@ public class AdminController {
 		ReadAdminInfoResponse readAdminInfo = adminService.readInfo(userDetails.getUsername());
 		return ResponseEntity.ok().body(readAdminInfo);
 	}
+
+	@PatchMapping
+	public ResponseEntity<Void> updateInfo(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated UpdateAdminInfoRequest updateAdminInfoRequest) {
+		adminService.updateInfo(userDetails.getUsername(), updateAdminInfoRequest);
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/AdminListRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/AdminListRequest.java
@@ -11,7 +11,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class AdminListRequest extends ListRequest {
 
-	private AdminRole role; // Optional: 역할별 필터링 조건
+	private AdminRole role;
 
 	// enum 파라미터를 문자열로 받을 경우 바인딩 오류 방지
 	public void setRole(String role) {

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/AdminListRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/AdminListRequest.java
@@ -1,0 +1,24 @@
+package com.roome.admin.roomeadminbe.domain.admin.dto.request;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
+import com.roome.admin.roomeadminbe.domain.common.dto.request.ListRequest;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+public class AdminListRequest extends ListRequest {
+
+	private AdminRole role; // Optional: 역할별 필터링 조건
+
+	// enum 파라미터를 문자열로 받을 경우 바인딩 오류 방지
+	public void setRole(String role) {
+		try {
+			this.role = AdminRole.valueOf(role.toUpperCase());
+		} catch (IllegalArgumentException | NullPointerException e) {
+			this.role = null;
+		}
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/UpdateAdminInfoRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/UpdateAdminInfoRequest.java
@@ -1,0 +1,13 @@
+package com.roome.admin.roomeadminbe.domain.admin.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateAdminInfoRequest {
+
+	private String username;
+	private String phoneNumber;
+	private String password;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,10 @@
+package com.roome.admin.roomeadminbe.domain.admin.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdatePasswordRequest {
+	private String beforePassword;
+	private String newPassword;
+	private String confirmPassword;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/response/AdminListResponse.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/response/AdminListResponse.java
@@ -1,0 +1,26 @@
+package com.roome.admin.roomeadminbe.domain.admin.dto.response;
+
+import com.roome.admin.roomeadminbe.domain.common.util.PagingUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminListResponse {
+	private List<AdminResponse> content;
+	private PagingUtil paging;
+
+	public static AdminListResponse from(Page<AdminResponse> page) {
+		return AdminListResponse.builder()
+				.content(page.getContent())
+				.paging(PagingUtil.from(page))
+				.build();
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/response/AdminResponse.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/response/AdminResponse.java
@@ -1,0 +1,24 @@
+package com.roome.admin.roomeadminbe.domain.admin.dto.response;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminResponse {
+	private Long id;
+	private String name;
+	private String email;
+	private AdminRole role;
+
+	public static AdminResponse from(Admin admin) {
+		return new AdminResponse(
+				admin.getAdminId(),
+				admin.getAdminEmail(),
+				admin.getAdminName(),
+				admin.getAdminRole()
+		);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/response/ReadAdminInfoResponse.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/dto/response/ReadAdminInfoResponse.java
@@ -1,0 +1,14 @@
+package com.roome.admin.roomeadminbe.domain.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReadAdminInfoResponse {
+	private String adminEmail;
+	private String username;
+	private String phoneNumber;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/ActivationStatus.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/ActivationStatus.java
@@ -1,0 +1,8 @@
+package com.roome.admin.roomeadminbe.domain.admin.entity;
+
+public enum ActivationStatus {
+
+	ACTIVE,
+	INACTIVE,
+	PENDING
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
@@ -40,11 +40,12 @@ public class Admin extends Timestamped {
 
 	public void updateTempPassword(String password) {
 		this.password = password;
+		this.activationStatus = ActivationStatus.ACTIVE;
 	}
 
 	public void updateInfo(String adminEmail, UpdateAdminInfoRequest updateAdminInfoRequest) {
-		this.adminName = updateAdminInfoRequest.getUsername();
-		this.phoneNumber = updateAdminInfoRequest.getPhoneNumber();
+		this.adminName = updateAdminInfoRequest.getUsername().equals("") ? adminName : updateAdminInfoRequest.getUsername();
+		this.phoneNumber = updateAdminInfoRequest.getPhoneNumber().equals("") ? phoneNumber : updateAdminInfoRequest.getPhoneNumber();
 	}
 
 	public void updatePassword(String adminEmail, String encryptedNewPassword) {

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
@@ -1,5 +1,6 @@
 package com.roome.admin.roomeadminbe.domain.admin.entity;
 
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.UpdateAdminInfoRequest;
 import com.roome.admin.roomeadminbe.domain.common.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -24,8 +25,30 @@ public class Admin extends Timestamped {
 	private String adminName;
 	private String adminEmail;
 	private String password;
+	private String phoneNumber;
+	@Enumerated(EnumType.STRING)
+	private ActivationStatus activationStatus;
 	private LocalDateTime deletedAt;
-	private Boolean isdeletedAt;
+	private Boolean isDeletedAt;
+	@Enumerated(EnumType.STRING)
 	private Status status;
 	private LocalDateTime lastLoginAt;
+
+	public boolean isActivated() {
+		return this.activationStatus == ActivationStatus.ACTIVE;
+	}
+
+	public void updateTempPassword(String password) {
+		this.password = password;
+	}
+
+	public void updateInfo(String adminEmail, UpdateAdminInfoRequest updateAdminInfoRequest) {
+		this.adminName = updateAdminInfoRequest.getUsername();
+		this.phoneNumber = updateAdminInfoRequest.getPhoneNumber();
+	}
+
+	public void updatePassword(String adminEmail, String encryptedNewPassword) {
+		this.password = encryptedNewPassword;
+	}
+
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
@@ -21,6 +21,7 @@ public class Admin extends Timestamped {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long adminId;
+	@Enumerated(EnumType.STRING)
 	private AdminRole adminRole;
 	private String adminName;
 	private String adminEmail;

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
@@ -52,4 +52,9 @@ public class Admin extends Timestamped {
 		this.password = encryptedNewPassword;
 	}
 
+	public void deleteAdminRole() {
+		this.activationStatus = ActivationStatus.PENDING;
+		this.deletedAt = LocalDateTime.now();
+		this.isDeletedAt = Boolean.TRUE;
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Admin.java
@@ -1,0 +1,31 @@
+package com.roome.admin.roomeadminbe.domain.admin.entity;
+
+import com.roome.admin.roomeadminbe.domain.common.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "admins")
+public class Admin extends Timestamped {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long adminId;
+	private AdminRole adminRole;
+	private String adminName;
+	private String adminEmail;
+	private String password;
+	private LocalDateTime deletedAt;
+	private Boolean isdeletedAt;
+	private Status status;
+	private LocalDateTime lastLoginAt;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/AdminRole.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/AdminRole.java
@@ -3,10 +3,8 @@ package com.roome.admin.roomeadminbe.domain.admin.entity;
 
 public enum AdminRole {
 	SUPER_ADMIN,
-	BEFORE_OPERATION_MANAGER,
 	OPERATION_MANAGER,
-	SYSTEM_MANAGER,
-	BEFORE_SYSTEM_MANAGER;
+	SYSTEM_MANAGER;
 
 	public String getRoleName() {
 		return "ROLE_" + this.name();

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/AdminRole.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/AdminRole.java
@@ -6,5 +6,9 @@ public enum AdminRole {
 	BEFORE_OPERATION_MANAGER,
 	OPERATION_MANAGER,
 	SYSTEM_MANAGER,
-	BEFORE_SYSTEM_MANAGER
+	BEFORE_SYSTEM_MANAGER;
+
+	public String getRoleName() {
+		return "ROLE_" + this.name();
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/AdminRole.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/AdminRole.java
@@ -1,0 +1,10 @@
+package com.roome.admin.roomeadminbe.domain.admin.entity;
+
+
+public enum AdminRole {
+	SUPER_ADMIN,
+	BEFORE_OPERATION_MANAGER,
+	OPERATION_MANAGER,
+	SYSTEM_MANAGER,
+	BEFORE_SYSTEM_MANAGER
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Status.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/entity/Status.java
@@ -1,0 +1,7 @@
+package com.roome.admin.roomeadminbe.domain.admin.entity;
+
+public enum Status {
+	ONLINE,
+	DORMANT,    // 휴면
+	OFFLINE
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
@@ -8,5 +8,8 @@ import java.util.Optional;
 
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long>, AdminRepositoryCustom {
-	Optional<Admin> findByAdminEmail(String adminEmail);
+    Optional<Admin> findByAdminEmail(String adminEmail);
+
+    // super admin 생성에 필요
+    boolean existsByAdminEmail(String email);
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface AdminRepository extends JpaRepository<Admin, Long> {
+public interface AdminRepository extends JpaRepository<Admin, Long>, AdminRepositoryCustom {
 	Optional<Admin> findByAdminEmail(String adminEmail);
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
@@ -4,6 +4,9 @@ import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
+	Optional<Admin> findByAdminEmail(String adminEmail);
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,9 @@
+package com.roome.admin.roomeadminbe.domain.admin.repository;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepositoryCustom.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.roome.admin.roomeadminbe.domain.admin.repository;
+
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.AdminListRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AdminRepositoryCustom {
+
+	Page<AdminResponse> findAll(AdminListRequest adminListRequest, Pageable pageable);
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepositoryImpl.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/repository/AdminRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.roome.admin.roomeadminbe.domain.admin.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.AdminListRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminResponse;
+import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.roome.admin.roomeadminbe.domain.admin.entity.QAdmin.admin;
+import static org.springframework.util.ObjectUtils.isEmpty;
+
+@RequiredArgsConstructor
+public class AdminRepositoryImpl implements AdminRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Page<AdminResponse> findAll(AdminListRequest adminListRequest, Pageable pageable) {
+		List<AdminResponse> list = jpaQueryFactory
+				.select(Projections.constructor(AdminResponse.class,
+						admin.adminId,
+						admin.adminName,
+						admin.adminEmail,
+						admin.adminRole))
+				.from(admin)
+				.where(adminRoleEq(adminListRequest.getRole()))
+				.orderBy(admin.createdAt.desc())
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.fetch();
+
+		Long count = jpaQueryFactory
+				.select(admin.count())
+				.from(admin)
+				.fetchOne();
+
+		return new PageImpl<>(list, pageable, count);
+	}
+
+	private BooleanExpression adminRoleEq(AdminRole adminRole) {
+		return isEmpty(adminRole) ? null : admin.adminRole.eq(adminRole);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
@@ -31,22 +31,27 @@ public class AdminService {
 
 	public void updateInfo(String adminEmail, UpdateAdminInfoRequest updateAdminInfoRequest) {
 		Admin admin = adminRepository.findByAdminEmail(adminEmail).orElseThrow();
-		if (passwordEncoder.matches(admin.getPassword(), updateAdminInfoRequest.getPassword())) {
-			admin.updateInfo(adminEmail, updateAdminInfoRequest);
+		if (!passwordEncoder.matches(updateAdminInfoRequest.getPassword(), admin.getPassword())) {
+			// exception 일괄 처리
+			throw new NoSuchElementException();
 		}
-		// exception 일괄 처리
-		throw new NoSuchElementException();
+		admin.updateInfo(adminEmail, updateAdminInfoRequest);
 	}
 
 	public void updatePassword(String adminEmail, UpdatePasswordRequest updatePasswordRequest) {
 		Admin admin = adminRepository.findByAdminEmail(adminEmail).orElseThrow();
+
+		// 비밀번호 불일치
+		if (!passwordEncoder.matches(updatePasswordRequest.getBeforePassword(), admin.getPassword())) {
+			// exception 일괄 처리 예정
+			throw new NoSuchElementException();
+		}
+
+		// 비밀번호, 비밀번호 확인 불일치  -> 프론트 처리시 삭제 예정
 		if (!updatePasswordRequest.getConfirmPassword().equals(updatePasswordRequest.getNewPassword())) {
 			throw new NoSuchElementException();
 		}
-		if (passwordEncoder.matches(admin.getPassword(), updatePasswordRequest.getBeforePassword())) {
-			admin.updatePassword(adminEmail, passwordEncoder.encode(updatePasswordRequest.getNewPassword()));
-		}
-		// exception 일괄 처리 예정
-		throw new NoSuchElementException();
+
+		admin.updatePassword(adminEmail, passwordEncoder.encode(updatePasswordRequest.getNewPassword()));
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
@@ -1,0 +1,30 @@
+package com.roome.admin.roomeadminbe.domain.admin.service;
+
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.UpdateAdminInfoRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.UpdatePasswordRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.ReadAdminInfoResponse;
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminService {
+
+	private final AdminRepository adminRepository;
+
+	public ReadAdminInfoResponse readInfo(String adminEmail) {
+		Admin admin = adminRepository.findByAdminEmail(adminEmail).orElseThrow();
+		return ReadAdminInfoResponse.builder()
+				.adminEmail(admin.getAdminEmail())
+				.username(admin.getAdminName())
+				.phoneNumber(admin.getPhoneNumber())
+				.build();
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
@@ -18,6 +18,7 @@ import java.util.NoSuchElementException;
 public class AdminService {
 
 	private final AdminRepository adminRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	public ReadAdminInfoResponse readInfo(String adminEmail) {
 		Admin admin = adminRepository.findByAdminEmail(adminEmail).orElseThrow();
@@ -26,5 +27,14 @@ public class AdminService {
 				.username(admin.getAdminName())
 				.phoneNumber(admin.getPhoneNumber())
 				.build();
+	}
+
+	public void updateInfo(String adminEmail, UpdateAdminInfoRequest updateAdminInfoRequest) {
+		Admin admin = adminRepository.findByAdminEmail(adminEmail).orElseThrow();
+		if (passwordEncoder.matches(admin.getPassword(), updateAdminInfoRequest.getPassword())) {
+			admin.updateInfo(adminEmail, updateAdminInfoRequest);
+		}
+		// exception 일괄 처리
+		throw new NoSuchElementException();
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/admin/service/AdminService.java
@@ -37,4 +37,16 @@ public class AdminService {
 		// exception 일괄 처리
 		throw new NoSuchElementException();
 	}
+
+	public void updatePassword(String adminEmail, UpdatePasswordRequest updatePasswordRequest) {
+		Admin admin = adminRepository.findByAdminEmail(adminEmail).orElseThrow();
+		if (!updatePasswordRequest.getConfirmPassword().equals(updatePasswordRequest.getNewPassword())) {
+			throw new NoSuchElementException();
+		}
+		if (passwordEncoder.matches(admin.getPassword(), updatePasswordRequest.getBeforePassword())) {
+			admin.updatePassword(adminEmail, passwordEncoder.encode(updatePasswordRequest.getNewPassword()));
+		}
+		// exception 일괄 처리 예정
+		throw new NoSuchElementException();
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.roome.admin.roomeadminbe.domain.auth.dto.request.LoginRequest;
 import com.roome.admin.roomeadminbe.domain.auth.dto.request.SendTempPasswordRequest;
 import com.roome.admin.roomeadminbe.domain.auth.service.AuthService;
 import com.roome.admin.roomeadminbe.global.security.jwt.filter.JwtFilter;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ import java.time.Duration;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/roome/bo/admin/common/auth")
+@RequestMapping("/admin/auth/login")
 public class AuthController {
 
 	private final AuthService authService;
@@ -56,4 +57,9 @@ public class AuthController {
 		return new ResponseEntity<>(tokenResponseDto, httpHeaders, HttpStatus.OK);
 	}
 
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		authService.logout(request, response);
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
@@ -7,7 +7,6 @@ import com.roome.admin.roomeadminbe.domain.auth.service.AuthService;
 import com.roome.admin.roomeadminbe.global.security.jwt.filter.JwtFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -23,43 +22,43 @@ import java.time.Duration;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/auth/login")
+@RequestMapping("/admin/auth")
 public class AuthController {
 
-	private final AuthService authService;
+    private final AuthService authService;
 
-	// 임시 password 발급 (첫 로그인)
-	@PostMapping("/password")
-	public ResponseEntity<Void> sendTempPassword(@RequestBody SendTempPasswordRequest sendTempPasswordRequest) {
-		authService.sendTempPassword(sendTempPasswordRequest);
-		return ResponseEntity.ok().build();
-	}
+    // 임시 password 발급 (첫 로그인)
+    @PostMapping("/password")
+    public ResponseEntity<Void> sendTempPassword(@RequestBody SendTempPasswordRequest sendTempPasswordRequest) {
+        authService.sendTempPassword(sendTempPasswordRequest);
+        return ResponseEntity.ok().build();
+    }
 
-	// 로그인
-	@PostMapping("/login")
-	public ResponseEntity<TokenResponseDto> authorize(@RequestBody @Validated LoginRequest loginRequestDto, HttpServletResponse response) {
-		TokenResponseDto tokenResponseDto = authService.login(loginRequestDto);
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<Void> authorize(@RequestBody @Validated LoginRequest loginRequestDto, HttpServletResponse response) {
+        TokenResponseDto tokenResponseDto = authService.login(loginRequestDto);
 
-		// accessToken -> header
-		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + tokenResponseDto.getAccessToken());
+        // accessToken -> header
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + tokenResponseDto.getAccessToken());
 
-		// refreshToken -> HttpOnly 쿠키
-		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokenResponseDto.getRefreshToken())
-				.httpOnly(true)
-				.secure(true)
-				.path("/")
-				.maxAge(Duration.ofDays(14))
-				.sameSite("Strict")
-				.build();
-		response.setHeader("Set-Cookie", refreshCookie.toString());
+        // refreshToken -> HttpOnly 쿠키
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokenResponseDto.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofDays(14))
+                .sameSite("Strict")
+                .build();
+        response.setHeader("Set-Cookie", refreshCookie.toString());
 
-		return new ResponseEntity<>(tokenResponseDto, httpHeaders, HttpStatus.OK);
-	}
+        return new ResponseEntity<>(httpHeaders, HttpStatus.OK);
+    }
 
-	@PostMapping("/logout")
-	public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-		authService.logout(request, response);
-		return ResponseEntity.noContent().build();
-	}
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        authService.logout(request, response);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.roome.admin.roomeadminbe.domain.auth.controller;
+
+import com.roome.admin.roomeadminbe.domain.auth.dto.TokenResponseDto;
+import com.roome.admin.roomeadminbe.domain.auth.dto.request.LoginRequest;
+import com.roome.admin.roomeadminbe.domain.auth.dto.request.SendTempPasswordRequest;
+import com.roome.admin.roomeadminbe.domain.auth.service.AuthService;
+import com.roome.admin.roomeadminbe.global.security.jwt.filter.JwtFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/roome/bo/admin/common/auth")
+public class AuthController {
+
+	private final AuthService authService;
+
+	// 임시 password 발급 (첫 로그인)
+	@PostMapping("/password")
+	public ResponseEntity<Void> sendTempPassword(@RequestBody SendTempPasswordRequest sendTempPasswordRequest) {
+		authService.sendTempPassword(sendTempPasswordRequest);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/controller/AuthController.java
@@ -33,4 +33,27 @@ public class AuthController {
 		authService.sendTempPassword(sendTempPasswordRequest);
 		return ResponseEntity.ok().build();
 	}
+
+	// 로그인
+	@PostMapping("/login")
+	public ResponseEntity<TokenResponseDto> authorize(@RequestBody @Validated LoginRequest loginRequestDto, HttpServletResponse response) {
+		TokenResponseDto tokenResponseDto = authService.login(loginRequestDto);
+
+		// accessToken -> header
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + tokenResponseDto.getAccessToken());
+
+		// refreshToken -> HttpOnly 쿠키
+		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokenResponseDto.getRefreshToken())
+				.httpOnly(true)
+				.secure(true)
+				.path("/")
+				.maxAge(Duration.ofDays(14))
+				.sameSite("Strict")
+				.build();
+		response.setHeader("Set-Cookie", refreshCookie.toString());
+
+		return new ResponseEntity<>(tokenResponseDto, httpHeaders, HttpStatus.OK);
+	}
+
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/TokenResponseDto.java
@@ -1,0 +1,15 @@
+package com.roome.admin.roomeadminbe.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponseDto {
+
+	private String accessToken;
+	private String refreshToken;
+
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.roome.admin.roomeadminbe.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+	@NotBlank
+	private String username;
+
+	@NotBlank
+	private String password;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/request/SendTempPasswordRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/request/SendTempPasswordRequest.java
@@ -1,0 +1,9 @@
+package com.roome.admin.roomeadminbe.domain.auth.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class SendTempPasswordRequest {
+
+	private String adminEmail;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/request/SendTempPasswordRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/dto/request/SendTempPasswordRequest.java
@@ -1,9 +1,11 @@
 package com.roome.admin.roomeadminbe.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
 import lombok.Getter;
 
 @Getter
 public class SendTempPasswordRequest {
 
+	@Email
 	private String adminEmail;
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
@@ -7,6 +7,9 @@ import com.roome.admin.roomeadminbe.domain.auth.dto.request.LoginRequest;
 import com.roome.admin.roomeadminbe.domain.auth.dto.request.SendTempPasswordRequest;
 import com.roome.admin.roomeadminbe.global.mail.MailService;
 import com.roome.admin.roomeadminbe.global.security.jwt.provider.TokenProvider;
+import com.roome.admin.roomeadminbe.global.security.jwt.service.RefreshTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,6 +20,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.NoSuchElementException;
+
+import static com.roome.admin.roomeadminbe.global.security.util.CookieUtil.deleteRefreshTokenCookie;
 
 @Service
 @Transactional
@@ -28,6 +34,7 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final TokenProvider tokenProvider;
 	private final AuthenticationManagerBuilder authenticationManagerBuilder;
+	private final RefreshTokenService refreshTokenService;
 
 	public void sendTempPassword(SendTempPasswordRequest sendTempPasswordRequest) {
 		Admin admin = adminRepository.findByAdminEmail(sendTempPasswordRequest.getAdminEmail())
@@ -50,6 +57,7 @@ public class AuthService {
 
 		Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
+
 		String accessToken = tokenProvider.createAccessToken(authentication);
 		String refreshToken = tokenProvider.createRefreshToken(authentication);
 
@@ -70,4 +78,20 @@ public class AuthService {
 		return sb.toString();
 	}
 
+	public void logout(HttpServletRequest request, HttpServletResponse response) {
+		// 1. AccessToken 추출
+		String accessToken = tokenProvider.resolveToken(request);
+		if (accessToken == null || !tokenProvider.validateAccessToken(accessToken)) {
+			throw new NoSuchElementException("유효하지 않은 AccessToken입니다.");
+		}
+
+		// 2. 사용자 정보 추출
+		Long userId = tokenProvider.getUserIdFromAccessToken(accessToken);
+
+		// 3. Redis에서 RefreshToken 삭제
+		refreshTokenService.deleteRefreshToken(userId);
+
+		// 4. 쿠키에서 RefreshToken 제거 (Set-Cookie: Max-Age=0)
+		deleteRefreshTokenCookie(response);
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
@@ -1,0 +1,61 @@
+package com.roome.admin.roomeadminbe.domain.auth.service;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
+import com.roome.admin.roomeadminbe.domain.auth.dto.TokenResponseDto;
+import com.roome.admin.roomeadminbe.domain.auth.dto.request.LoginRequest;
+import com.roome.admin.roomeadminbe.domain.auth.dto.request.SendTempPasswordRequest;
+import com.roome.admin.roomeadminbe.global.mail.MailService;
+import com.roome.admin.roomeadminbe.global.security.jwt.provider.TokenProvider;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final AdminRepository adminRepository;
+	private final MailService mailService;
+	private final PasswordEncoder passwordEncoder;
+	private final TokenProvider tokenProvider;
+	private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+	public void sendTempPassword(SendTempPasswordRequest sendTempPasswordRequest) {
+		Admin admin = adminRepository.findByAdminEmail(sendTempPasswordRequest.getAdminEmail())
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관리자입니다."));
+
+		// 1. 임시 비밀번호 생성
+		String tempPassword = generateRandomPassword();
+
+		// 2. 비밀번호 저장
+		admin.updateTempPassword(passwordEncoder.encode(tempPassword));
+		adminRepository.save(admin);
+
+		// 3. 메일 전송 요청
+		mailService.sendTempPasswordEmail(admin.getAdminEmail(), tempPassword);
+	}
+
+	// 랜덤 비밀번호 생성 로직
+	private String generateRandomPassword() {
+		int length = 10;
+		String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%";
+		StringBuilder sb = new StringBuilder();
+		SecureRandom random = new SecureRandom();
+
+		for (int i = 0; i < length; i++) {
+			int idx = random.nextInt(chars.length());
+			sb.append(chars.charAt(idx));
+		}
+		return sb.toString();
+	}
+
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
@@ -44,6 +44,18 @@ public class AuthService {
 		mailService.sendTempPasswordEmail(admin.getAdminEmail(), tempPassword);
 	}
 
+	public TokenResponseDto login(LoginRequest loginRequestDto) {
+		UsernamePasswordAuthenticationToken authenticationToken =
+				new UsernamePasswordAuthenticationToken(loginRequestDto.getUsername(), loginRequestDto.getPassword());
+
+		Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		String accessToken = tokenProvider.createAccessToken(authentication);
+		String refreshToken = tokenProvider.createRefreshToken(authentication);
+
+		return new TokenResponseDto(accessToken, refreshToken);
+	}
+
 	// 랜덤 비밀번호 생성 로직
 	private String generateRandomPassword() {
 		int length = 10;

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/auth/service/AuthService.java
@@ -64,20 +64,6 @@ public class AuthService {
 		return new TokenResponseDto(accessToken, refreshToken);
 	}
 
-	// 랜덤 비밀번호 생성 로직
-	private String generateRandomPassword() {
-		int length = 10;
-		String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%";
-		StringBuilder sb = new StringBuilder();
-		SecureRandom random = new SecureRandom();
-
-		for (int i = 0; i < length; i++) {
-			int idx = random.nextInt(chars.length());
-			sb.append(chars.charAt(idx));
-		}
-		return sb.toString();
-	}
-
 	public void logout(HttpServletRequest request, HttpServletResponse response) {
 		// 1. AccessToken 추출
 		String accessToken = tokenProvider.resolveToken(request);
@@ -93,5 +79,19 @@ public class AuthService {
 
 		// 4. 쿠키에서 RefreshToken 제거 (Set-Cookie: Max-Age=0)
 		deleteRefreshTokenCookie(response);
+	}
+
+	// 랜덤 비밀번호 생성 로직
+	private String generateRandomPassword() {
+		int length = 10;
+		String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%";
+		StringBuilder sb = new StringBuilder();
+		SecureRandom random = new SecureRandom();
+
+		for (int i = 0; i < length; i++) {
+			int idx = random.nextInt(chars.length());
+			sb.append(chars.charAt(idx));
+		}
+		return sb.toString();
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/common/dto/request/ListRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/common/dto/request/ListRequest.java
@@ -1,0 +1,42 @@
+package com.roome.admin.roomeadminbe.domain.common.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class ListRequest {
+
+	@Builder.Default
+	private Integer page = 1; // 사용자는 1부터 시작한다고 가정
+
+	@Builder.Default
+	private Integer pageSize = 10;
+
+	@Builder.Default
+	private Sort.Direction sortDirection = Sort.Direction.DESC;
+
+	private String column;
+
+	public Pageable toPageable() {
+		int safePage = (page != null && page > 0) ? page - 1 : 0;
+		String sortBy = (column != null && !column.isBlank()) ? column : "createdAt";
+		return PageRequest.of(safePage, pageSize, sortDirection, sortBy);
+	}
+
+	public void setSortDirection(String sortDirection) {
+		if ("asc".equalsIgnoreCase(sortDirection)) {
+			this.sortDirection = Sort.Direction.ASC;
+		} else if ("desc".equalsIgnoreCase(sortDirection)) {
+			this.sortDirection = Sort.Direction.DESC;
+		}
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/common/dto/response/ListResponse.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/common/dto/response/ListResponse.java
@@ -1,0 +1,26 @@
+package com.roome.admin.roomeadminbe.domain.common.dto.response;
+
+import com.roome.admin.roomeadminbe.domain.common.util.PagingUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class ListResponse<T> {
+	private PagingUtil pagingUtil;
+	private List<T> content;
+
+	public static <T> ListResponse<T> from(Page<T> page) {
+		return ListResponse.<T>builder()
+				.pagingUtil(PagingUtil.from(page))
+				.content(page.getContent())
+				.build();
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/common/entity/Timestamped.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/common/entity/Timestamped.java
@@ -1,0 +1,29 @@
+package com.roome.admin.roomeadminbe.domain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+	@CreatedDate
+	@Column(updatable = false)
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/common/util/PagingUtil.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/common/util/PagingUtil.java
@@ -1,0 +1,58 @@
+package com.roome.admin.roomeadminbe.domain.common.util;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PagingUtil {
+
+	private final long totalElements;
+	private final int totalPages;
+	private final int pageNumber;
+	private final int pageSize;
+	private final int totalPageGroups;
+	private final int pageGroupSize = 5;
+	private final int pageGroup;
+	private final int startPage;
+	private final int endPage;
+	private final boolean existPrePageGroup;
+	private final boolean existNextPageGroup;
+
+	private PagingUtil(long totalElements, int totalPages, int pageNumber, int pageSize) {
+		this.totalElements = totalElements;
+		this.totalPages = totalPages;
+		this.pageNumber = pageNumber + 1;
+		this.pageSize = pageSize;
+		this.totalPageGroups = calculateTotalPageGroups();
+		this.pageGroup = calculatePageGroup();
+		this.startPage = calculateStartPage();
+		this.endPage = calculateEndPage();
+		this.existPrePageGroup = pageGroup > 1;
+		this.existNextPageGroup = pageGroup < totalPageGroups;
+	}
+
+	public static PagingUtil from(Page<?> page) {
+		return new PagingUtil(
+				page.getTotalElements(),
+				page.getTotalPages(),
+				page.getNumber(),
+				page.getSize()
+		);
+	}
+
+	private int calculateTotalPageGroups() {
+		return (int) Math.ceil((double) totalPages / pageGroupSize);
+	}
+
+	private int calculatePageGroup() {
+		return (int) Math.ceil((double) pageNumber / pageGroupSize);
+	}
+
+	private int calculateStartPage() {
+		return (pageGroup - 1) * pageGroupSize + 1;
+	}
+
+	private int calculateEndPage() {
+		return Math.min(pageGroup * pageGroupSize, totalPages);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
@@ -1,14 +1,11 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.controller;
 
-import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequestDto;
+import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequest;
 import com.roome.admin.roomeadminbe.domain.superadmin.service.SuperAdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,8 +14,8 @@ public class SuperAdminController {
 
 	private final SuperAdminService superAdminService;
 
-	@PostMapping
-	public ResponseEntity<Void> inviteAdmin(@RequestBody @Validated InviteAdminRequestDto inviteAdminRequestDto ) {
+	@PostMapping("/invite")
+	public ResponseEntity<Void> inviteAdmin(@RequestBody @Validated InviteAdminRequest inviteAdminRequestDto ) {
 		superAdminService.inviteAdmin(inviteAdminRequestDto);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
@@ -6,6 +6,7 @@ import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminReq
 import com.roome.admin.roomeadminbe.domain.superadmin.service.SuperAdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
@@ -18,20 +19,23 @@ public class SuperAdminController {
 
     private final SuperAdminService superAdminService;
 
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
     @PostMapping("/invite")
     public ResponseEntity<Void> inviteAdmin(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated InviteAdminRequest inviteAdminRequestDto) {
         superAdminService.inviteAdmin(inviteAdminRequestDto);
         return ResponseEntity.ok().build();
     }
 
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
     @GetMapping("/admins")
     public ResponseEntity<AdminListResponse> getAdminList(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute AdminListRequest adminListRequest) {
         AdminListResponse adminListResponse = superAdminService.getAdminList(adminListRequest);
         return ResponseEntity.ok().body(adminListResponse);
     }
 
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
     @PatchMapping("/admins/{adminId}/delete")
-    public ResponseEntity<Void> deleteAdminRole(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long adminId) {
+    public ResponseEntity<Void> deleteAdminRole(@AuthenticationPrincipal UserDetails userDetails, @PathVariable("adminId") Long adminId) {
         superAdminService.deleteAdminRole(adminId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
@@ -1,22 +1,34 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.controller;
 
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminListResponse;
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.AdminListRequest;
 import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminResponse;
 import com.roome.admin.roomeadminbe.domain.superadmin.service.SuperAdminService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/super")
+@RequestMapping("/admin/super")
 public class SuperAdminController {
 
 	private final SuperAdminService superAdminService;
 
 	@PostMapping("/invite")
-	public ResponseEntity<Void> inviteAdmin(@RequestBody @Validated InviteAdminRequest inviteAdminRequestDto ) {
+	public ResponseEntity<Void> inviteAdmin(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated InviteAdminRequest inviteAdminRequestDto ) {
 		superAdminService.inviteAdmin(inviteAdminRequestDto);
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/admins")
+	public ResponseEntity<AdminListResponse> getAdminList(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute AdminListRequest adminListRequest) {
+		AdminListResponse adminListResponse = superAdminService.getAdminList(adminListRequest);
+		return ResponseEntity.ok().body(adminListResponse);
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
@@ -1,0 +1,25 @@
+package com.roome.admin.roomeadminbe.domain.superadmin.controller;
+
+import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequestDto;
+import com.roome.admin.roomeadminbe.domain.superadmin.service.SuperAdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/super")
+public class SuperAdminController {
+
+	private final SuperAdminService superAdminService;
+
+	@PostMapping
+	public ResponseEntity<Void> inviteAdmin(@RequestBody @Validated InviteAdminRequestDto inviteAdminRequestDto ) {
+		superAdminService.inviteAdmin(inviteAdminRequestDto);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/controller/SuperAdminController.java
@@ -1,12 +1,10 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.controller;
 
-import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminListResponse;
 import com.roome.admin.roomeadminbe.domain.admin.dto.request.AdminListRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminListResponse;
 import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequest;
-import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminResponse;
 import com.roome.admin.roomeadminbe.domain.superadmin.service.SuperAdminService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,17 +16,23 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/admin/super")
 public class SuperAdminController {
 
-	private final SuperAdminService superAdminService;
+    private final SuperAdminService superAdminService;
 
-	@PostMapping("/invite")
-	public ResponseEntity<Void> inviteAdmin(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated InviteAdminRequest inviteAdminRequestDto ) {
-		superAdminService.inviteAdmin(inviteAdminRequestDto);
-		return ResponseEntity.ok().build();
-	}
+    @PostMapping("/invite")
+    public ResponseEntity<Void> inviteAdmin(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Validated InviteAdminRequest inviteAdminRequestDto) {
+        superAdminService.inviteAdmin(inviteAdminRequestDto);
+        return ResponseEntity.ok().build();
+    }
 
-	@GetMapping("/admins")
-	public ResponseEntity<AdminListResponse> getAdminList(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute AdminListRequest adminListRequest) {
-		AdminListResponse adminListResponse = superAdminService.getAdminList(adminListRequest);
-		return ResponseEntity.ok().body(adminListResponse);
-	}
+    @GetMapping("/admins")
+    public ResponseEntity<AdminListResponse> getAdminList(@AuthenticationPrincipal UserDetails userDetails, @ModelAttribute AdminListRequest adminListRequest) {
+        AdminListResponse adminListResponse = superAdminService.getAdminList(adminListRequest);
+        return ResponseEntity.ok().body(adminListResponse);
+    }
+
+    @PatchMapping("/admins/{adminId}/delete")
+    public ResponseEntity<Void> deleteAdminRole(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long adminId) {
+        superAdminService.deleteAdminRole(adminId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/dto/request/InviteAdminRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/dto/request/InviteAdminRequest.java
@@ -1,6 +1,7 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.dto.request;
 
 import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
+import jakarta.validation.constraints.Email;
 import lombok.Getter;
 
 @Getter
@@ -8,6 +9,7 @@ public class InviteAdminRequest {
 
 	private AdminRole adminRole;
 	private String adminName;
+	@Email
 	private String adminEmail;
 	private String phoneNumber;
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/dto/request/InviteAdminRequest.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/dto/request/InviteAdminRequest.java
@@ -1,16 +1,13 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.dto.request;
 
 import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
-import com.roome.admin.roomeadminbe.domain.admin.entity.Status;
 import lombok.Getter;
-import org.springframework.validation.annotation.Validated;
-
-import java.time.LocalDateTime;
 
 @Getter
-public class InviteAdminRequestDto {
+public class InviteAdminRequest {
 
 	private AdminRole adminRole;
 	private String adminName;
 	private String adminEmail;
+	private String phoneNumber;
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/dto/request/InviteAdminRequestDto.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/dto/request/InviteAdminRequestDto.java
@@ -1,0 +1,16 @@
+package com.roome.admin.roomeadminbe.domain.superadmin.dto.request;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
+import com.roome.admin.roomeadminbe.domain.admin.entity.Status;
+import lombok.Getter;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class InviteAdminRequestDto {
+
+	private AdminRole adminRole;
+	private String adminName;
+	private String adminEmail;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
@@ -1,8 +1,9 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.service;
 
+import com.roome.admin.roomeadminbe.domain.admin.entity.ActivationStatus;
 import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
 import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
-import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequestDto;
+import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequest;
 import com.roome.admin.roomeadminbe.global.mail.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,15 +14,19 @@ public class SuperAdminService {
 
 	private final MailService mailService;
 	private final AdminRepository adminRepository;
-	public void inviteAdmin(InviteAdminRequestDto inviteAdminRequestDto) {
+	public void inviteAdmin(InviteAdminRequest inviteAdminRequestDto) {
 
 		Admin newAdmin = Admin.builder()
 				.adminRole(inviteAdminRequestDto.getAdminRole())
 				.adminName(inviteAdminRequestDto.getAdminName())
 				.adminEmail(inviteAdminRequestDto.getAdminEmail())
+				.phoneNumber(inviteAdminRequestDto.getPhoneNumber())
+				// 관리자 인증 전
+				.activationStatus(ActivationStatus.PENDING)
+				// 최초 가입 전 비밀번호 null
 				.password(null)
 				.deletedAt(null)
-				.isdeletedAt(false)
+				.isDeletedAt(false)
 				.lastLoginAt(null)
 				.status(null)
 				.build();

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
@@ -48,4 +48,9 @@ public class SuperAdminService {
 
 		return AdminListResponse.from(page);
 	}
+
+	public void deleteAdminRole(Long adminId) {
+		Admin admin = adminRepository.findById(adminId).orElseThrow();
+		admin.deleteAdminRole();
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
@@ -1,0 +1,31 @@
+package com.roome.admin.roomeadminbe.domain.superadmin.service;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
+import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequestDto;
+import com.roome.admin.roomeadminbe.global.mail.MailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SuperAdminService {
+
+	private final MailService mailService;
+	private final AdminRepository adminRepository;
+	public void inviteAdmin(InviteAdminRequestDto inviteAdminRequestDto) {
+
+		Admin newAdmin = Admin.builder()
+				.adminRole(inviteAdminRequestDto.getAdminRole())
+				.adminName(inviteAdminRequestDto.getAdminName())
+				.adminEmail(inviteAdminRequestDto.getAdminEmail())
+				.password(null)
+				.deletedAt(null)
+				.isdeletedAt(false)
+				.lastLoginAt(null)
+				.status(null)
+				.build();
+		adminRepository.save(newAdmin);
+		mailService.sendInvitationEmail(inviteAdminRequestDto.getAdminEmail());
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/superadmin/service/SuperAdminService.java
@@ -1,14 +1,21 @@
 package com.roome.admin.roomeadminbe.domain.superadmin.service;
 
+import com.roome.admin.roomeadminbe.domain.admin.dto.request.AdminListRequest;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminListResponse;
+import com.roome.admin.roomeadminbe.domain.admin.dto.response.AdminResponse;
 import com.roome.admin.roomeadminbe.domain.admin.entity.ActivationStatus;
 import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
 import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
 import com.roome.admin.roomeadminbe.domain.superadmin.dto.request.InviteAdminRequest;
 import com.roome.admin.roomeadminbe.global.mail.MailService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class SuperAdminService {
 
@@ -32,5 +39,13 @@ public class SuperAdminService {
 				.build();
 		adminRepository.save(newAdmin);
 		mailService.sendInvitationEmail(inviteAdminRequestDto.getAdminEmail());
+	}
+
+	public AdminListResponse getAdminList(AdminListRequest adminListRequest) {
+		Pageable pageable = adminListRequest.toPageable();
+
+		Page<AdminResponse> page = adminRepository.findAll(adminListRequest, pageable);
+
+		return AdminListResponse.from(page);
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/AsyncConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.roome.admin.roomeadminbe.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/JwtSecurityConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/JwtSecurityConfig.java
@@ -1,0 +1,24 @@
+package com.roome.admin.roomeadminbe.global.config;
+
+import com.roome.admin.roomeadminbe.global.security.jwt.filter.JwtFilter;
+import com.roome.admin.roomeadminbe.global.security.jwt.provider.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+	private final TokenProvider tokenProvider;
+
+	@Override
+	public void configure(HttpSecurity http) {
+
+		http.addFilterBefore(
+				new JwtFilter(tokenProvider),
+				UsernamePasswordAuthenticationFilter.class
+		);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/QueryDslConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.roome.admin.roomeadminbe.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/RedisConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/RedisConfig.java
@@ -16,13 +16,13 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-	@Value("${spring.data.redis.host:localhost}") // 기본값 설정
+	@Value("${spring.data.redis.host}")
 	private String host;
 
-	@Value("${spring.data.redis.port:6379}")
+	@Value("${spring.data.redis.port}")
 	private int port;
 
-	@Value("${spring.data.redis.password:}") // 비밀번호가 없을 수도 있으므로 기본값 ""
+	@Value("${spring.data.redis.password}")
 	private String password;
 
 	@Bean

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/RedisConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/RedisConfig.java
@@ -1,0 +1,69 @@
+package com.roome.admin.roomeadminbe.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Slf4j
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host:localhost}") // 기본값 설정
+	private String host;
+
+	@Value("${spring.data.redis.port:6379}")
+	private int port;
+
+	@Value("${spring.data.redis.password:}") // 비밀번호가 없을 수도 있으므로 기본값 ""
+	private String password;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+		config.setHostName(host);
+		config.setPort(port);
+		config.setPassword(password);
+
+		LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+		factory.afterPropertiesSet(); // 강제 초기화
+
+		// Redis 연결 확인 (Ping 테스트)
+		try {
+			String result = factory.getConnection().ping();
+			log.info("Redis 연결 성공! 응답: {}", result);
+		} catch (Exception e) {
+			log.error("Redis 연결 실패: {}", e.getMessage(), e);
+		}
+
+		return factory;
+	}
+
+	@Bean(name = "refreshTokenRedisTemplate")
+	public RedisTemplate<String, String> refreshTokenRedisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// key/value 직렬화 방식
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+
+		return template;
+	}
+
+	@Bean(name = "blacklistRedisTemplate")
+	public RedisTemplate<String, String> blacklistRedisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/SecurityConfig.java
@@ -50,8 +50,8 @@ public class SecurityConfig {
 				.authorizeHttpRequests(authorizeRequests ->
 						authorizeRequests
 								.requestMatchers("/api/admin/super/invite").permitAll()
-//								.requestMatchers("/roome/bo/admin/common/auth/password").permitAll()
-//								.requestMatchers("/roome/bo/admin/common/auth/login").permitAll()
+								.requestMatchers("/roome/bo/admin/common/auth/password").permitAll()
+								.requestMatchers("/roome/bo/admin/common/auth/login").permitAll()
 								.requestMatchers(PathRequest.toH2Console()).permitAll()
 								.requestMatchers("/favicon.ico").permitAll()
 								.anyRequest().authenticated()

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.roome.admin.roomeadminbe.global.config;
+
+import com.roome.admin.roomeadminbe.global.security.jwt.handler.JwtAccessDeniedHandler;
+import com.roome.admin.roomeadminbe.global.security.jwt.handler.JwtAuthenticationEntryPoint;
+import com.roome.admin.roomeadminbe.global.security.jwt.provider.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final TokenProvider tokenProvider;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+		JwtSecurityConfig jwtSecurityConfig = new JwtSecurityConfig(tokenProvider);
+
+		httpSecurity
+				.csrf(csrf -> csrf.disable())
+				.exceptionHandling(exceptionHandling ->
+						exceptionHandling
+								.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+								.accessDeniedHandler(jwtAccessDeniedHandler)
+				)
+				.headers(headers ->
+						headers
+								.frameOptions(frameOptions -> frameOptions.sameOrigin())
+				)
+				.sessionManagement(sessionManagement ->
+						sessionManagement
+								.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+				)
+				.authorizeHttpRequests(authorizeRequests ->
+						authorizeRequests
+								.requestMatchers("/api/admin/super/invite").permitAll()
+//								.requestMatchers("/roome/bo/admin/common/auth/password").permitAll()
+//								.requestMatchers("/roome/bo/admin/common/auth/login").permitAll()
+								.requestMatchers(PathRequest.toH2Console()).permitAll()
+								.requestMatchers("/favicon.ico").permitAll()
+								.anyRequest().authenticated()
+				);
+
+		jwtSecurityConfig.configure(httpSecurity); // JwtSecurityConfig를 적용
+
+		return httpSecurity.build();
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -15,6 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableMethodSecurity(prePostEnabled = true)
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
@@ -49,9 +51,8 @@ public class SecurityConfig {
 				)
 				.authorizeHttpRequests(authorizeRequests ->
 						authorizeRequests
-								.requestMatchers("/api/admin/super/invite").permitAll()
-								.requestMatchers("/roome/bo/admin/common/auth/password").permitAll()
-								.requestMatchers("/roome/bo/admin/common/auth/login").permitAll()
+								.requestMatchers("/admin/auth/login").permitAll()
+								.requestMatchers("/admin/auth/password").permitAll()
 								.requestMatchers(PathRequest.toH2Console()).permitAll()
 								.requestMatchers("/favicon.ico").permitAll()
 								.anyRequest().authenticated()

--- a/src/main/java/com/roome/admin/roomeadminbe/global/init/AdminInitializer.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/init/AdminInitializer.java
@@ -1,0 +1,38 @@
+package com.roome.admin.roomeadminbe.global.init;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.ActivationStatus;
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
+import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class AdminInitializer implements CommandLineRunner {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) {
+        String email = "super@admin.com";
+
+        boolean exists = adminRepository.existsByAdminEmail(email);
+
+        if (!exists) {
+            Admin superAdmin = Admin.builder()
+                    .adminEmail(email)
+                    .adminName("최고 관리자")
+                    .password(passwordEncoder.encode("superAdmin1!"))
+                    .adminRole(AdminRole.SUPER_ADMIN)
+                    .activationStatus(ActivationStatus.ACTIVE)
+                    .build();
+
+            adminRepository.save(superAdmin);
+            System.out.println("슈퍼 어드민 등록 완료");
+        }
+    }
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/mail/MailService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/mail/MailService.java
@@ -1,19 +1,24 @@
 package com.roome.admin.roomeadminbe.global.mail;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class MailService {
 
 	private final JavaMailSender mailSender;
 
+	@Async
 	public void sendInvitationEmail(String toEmail) {
-		String subject = "관리자 초대 메일";
-		String message = """
+		try {
+			String subject = "관리자 초대 메일";
+			String message = """
                 안녕하세요, 새로운 관리자 계정을 생성하려면 아래 링크를 클릭해주세요:
 
                 %s
@@ -21,17 +26,24 @@ public class MailService {
                 감사합니다.
                 """.formatted("https://roome-be.io.kr/login");
 
-		SimpleMailMessage email = new SimpleMailMessage();
-		email.setTo(toEmail);
-		email.setSubject(subject);
-		email.setText(message);
+			SimpleMailMessage email = new SimpleMailMessage();
+			email.setTo(toEmail);
+			email.setSubject(subject);
+			email.setText(message);
 
-		mailSender.send(email);
+			mailSender.send(email);
+			log.info("초대 메일 전송 성공 - 대상: {}", toEmail);
+
+		} catch (Exception e) {
+			log.error("초대 메일 전송 실패 - 대상: {}, 사유: {}", toEmail, e.getMessage(), e);
+		}
 	}
 
+	@Async
 	public void sendTempPasswordEmail(String toEmail, String tempPassword) {
-		String subject = "[roome 관리자] 임시 비밀번호 안내";
-		String message = """
+		try {
+			String subject = "[roome 관리자] 임시 비밀번호 안내";
+			String message = """
         안녕하세요,
 
         요청하신 임시 비밀번호는 아래와 같습니다:
@@ -43,11 +55,16 @@ public class MailService {
         감사합니다.
         """.formatted(tempPassword);
 
-		SimpleMailMessage email = new SimpleMailMessage();
-		email.setTo(toEmail);
-		email.setSubject(subject);
-		email.setText(message);
+			SimpleMailMessage email = new SimpleMailMessage();
+			email.setTo(toEmail);
+			email.setSubject(subject);
+			email.setText(message);
 
-		mailSender.send(email);
+			mailSender.send(email);
+			log.info("임시 비밀번호 메일 전송 성공 - 대상: {}", toEmail);
+
+		} catch (Exception e) {
+			log.error("임시 비밀번호 메일 전송 실패 - 대상: {}, 사유: {}", toEmail, e.getMessage(), e);
+		}
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/mail/MailService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/mail/MailService.java
@@ -28,4 +28,26 @@ public class MailService {
 
 		mailSender.send(email);
 	}
+
+	public void sendTempPasswordEmail(String toEmail, String tempPassword) {
+		String subject = "[roome 관리자] 임시 비밀번호 안내";
+		String message = """
+        안녕하세요,
+
+        요청하신 임시 비밀번호는 아래와 같습니다:
+
+        👉 %s
+
+        로그인 후 반드시 비밀번호를 변경해주세요.
+
+        감사합니다.
+        """.formatted(tempPassword);
+
+		SimpleMailMessage email = new SimpleMailMessage();
+		email.setTo(toEmail);
+		email.setSubject(subject);
+		email.setText(message);
+
+		mailSender.send(email);
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/mail/MailService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/mail/MailService.java
@@ -1,0 +1,31 @@
+package com.roome.admin.roomeadminbe.global.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+	private final JavaMailSender mailSender;
+
+	public void sendInvitationEmail(String toEmail) {
+		String subject = "관리자 초대 메일";
+		String message = """
+                안녕하세요, 새로운 관리자 계정을 생성하려면 아래 링크를 클릭해주세요:
+
+                %s
+
+                감사합니다.
+                """.formatted("https://roome-be.io.kr/login");
+
+		SimpleMailMessage email = new SimpleMailMessage();
+		email.setTo(toEmail);
+		email.setSubject(subject);
+		email.setText(message);
+
+		mailSender.send(email);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/controller/TokenController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/controller/TokenController.java
@@ -1,0 +1,22 @@
+package com.roome.admin.roomeadminbe.global.security.jwt.controller;
+
+import com.roome.admin.roomeadminbe.global.security.jwt.service.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+
+	private final TokenService tokenService;
+
+	@PostMapping("/refresh")
+	public ResponseEntity<Void> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+		tokenService.refreshAccessToken(request, response);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/filter/JwtFilter.java
@@ -1,0 +1,54 @@
+package com.roome.admin.roomeadminbe.global.security.jwt.filter;
+
+import com.roome.admin.roomeadminbe.global.security.jwt.provider.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends GenericFilterBean {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
+	private final TokenProvider tokenProvider;
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException, IOException {
+		HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+		String jwt = resolveToken(httpServletRequest);
+		String requestURI = httpServletRequest.getRequestURI();
+
+		if (StringUtils.hasText(jwt) && tokenProvider.validateAccessToken(jwt)) {
+			Authentication authentication = tokenProvider.getAuthenticationFromAccessToken(jwt);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			logger.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
+		} else {
+			logger.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+		}
+
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/filter/JwtFilter.java
@@ -28,7 +28,7 @@ public class JwtFilter extends GenericFilterBean {
 	@Override
 	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException, IOException {
 		HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-		String jwt = resolveToken(httpServletRequest);
+		String jwt = tokenProvider.resolveToken(httpServletRequest);
 		String requestURI = httpServletRequest.getRequestURI();
 
 		if (StringUtils.hasText(jwt) && tokenProvider.validateAccessToken(jwt)) {
@@ -40,15 +40,5 @@ public class JwtFilter extends GenericFilterBean {
 		}
 
 		filterChain.doFilter(servletRequest, servletResponse);
-	}
-
-	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-			return bearerToken.substring(7);
-		}
-
-		return null;
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package com.roome.admin.roomeadminbe.global.security.jwt.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException, IOException {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,18 @@
+package com.roome.admin.roomeadminbe.global.security.jwt.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException, IOException {
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/provider/TokenProvider.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/provider/TokenProvider.java
@@ -1,8 +1,10 @@
 package com.roome.admin.roomeadminbe.global.security.jwt.provider;
 
+import com.roome.admin.roomeadminbe.global.security.model.AdminDetails;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +17,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.util.Arrays;
@@ -27,8 +30,8 @@ import java.util.stream.Collectors;
 @Slf4j
 public class TokenProvider implements InitializingBean {
 
-	private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
 	private static final String AUTHORITIES_KEY = "auth";
+	private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
 	private final String accessSecret;
 	private final long accessTokenValidityInMillis;
 	private final String refreshSecret;
@@ -56,13 +59,17 @@ public class TokenProvider implements InitializingBean {
 	}
 
 	public String createAccessToken(Authentication authentication) {
+		AdminDetails principal = (AdminDetails) authentication.getPrincipal();
+
 		String authorities = authentication.getAuthorities().stream()
 				.map(GrantedAuthority::getAuthority)
 				.collect(Collectors.joining(","));
 
 		long now = System.currentTimeMillis();
+
 		return Jwts.builder()
-				.setSubject(authentication.getName())
+				.setSubject(principal.getAdminId().toString())
+				.claim("email", principal.getUsername())
 				.claim("auth", authorities)
 				.setIssuedAt(new Date(now))
 				.setExpiration(new Date(now + accessTokenValidityInMillis))
@@ -71,14 +78,22 @@ public class TokenProvider implements InitializingBean {
 	}
 
 	public String createRefreshToken(Authentication authentication) {
+		AdminDetails principal = (AdminDetails) authentication.getPrincipal();
+
+		Long userId = principal.getAdminId();
+		String email = principal.getUsername();
+
 		long now = System.currentTimeMillis();
+
 		return Jwts.builder()
-				.setSubject(authentication.getName())
+				.setSubject(userId.toString())
+				.claim("email", email)
 				.setIssuedAt(new Date(now))
 				.setExpiration(new Date(now + refreshTokenValidityInMillis))
 				.signWith(refreshKey, SignatureAlgorithm.HS256)
 				.compact();
 	}
+
 	// 토큰으로 클레임을 만들고 이를 이용해 유저 객체를 만들어서 최종적으로 authentication 객체를 리턴
 	public Authentication getAuthenticationFromAccessToken(String token) {
 		Claims claims = Jwts.parserBuilder()
@@ -103,10 +118,16 @@ public class TokenProvider implements InitializingBean {
 		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
 	}
 
-	public Long getUserFromRefreshToken(String token) {
-		Claims claims = getRefreshTokenClaims(token);
-		return Long.valueOf(claims.getSubject()); // subject에 userId가 담겨있다고 가정
+	public Long getUserIdFromAccessToken(String accessToken) {
+		Claims claims = getAccessTokenClaims(accessToken);
+		return Long.valueOf(claims.getSubject()); // subject에 userId가 저장되어 있음
 	}
+
+	public Long getUserFromRefreshToken(String refreshToken) {
+		Claims claims = getRefreshTokenClaims(refreshToken);
+		return Long.valueOf(claims.getSubject());
+	}
+
 	public Claims getAccessTokenClaims(String token) {
 		return parseClaims(token, accessKey);
 	}
@@ -122,6 +143,15 @@ public class TokenProvider implements InitializingBean {
 				.parseClaimsJws(token)
 				.getBody();
 	}
+
+	public String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader("Authorization");
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+
 	// 토큰의 유효성 검증을 수행
 	public boolean validateAccessToken(String token) {
 		return validateToken(token, accessKey);

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/provider/TokenProvider.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/provider/TokenProvider.java
@@ -1,0 +1,152 @@
+package com.roome.admin.roomeadminbe.global.security.jwt.provider;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class TokenProvider implements InitializingBean {
+
+	private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+	private static final String AUTHORITIES_KEY = "auth";
+	private final String accessSecret;
+	private final long accessTokenValidityInMillis;
+	private final String refreshSecret;
+	private final long refreshTokenValidityInMillis;
+	private SecretKey accessKey;
+	private SecretKey refreshKey;
+
+	public TokenProvider(
+			@Value("${jwt.access-token.secret}") String accessSecret,
+			@Value("${jwt.access-token.validity-in-seconds}") long accessValidity,
+			@Value("${jwt.refresh-token.secret}") String refreshSecret,
+			@Value("${jwt.refresh-token.validity-in-seconds}") long refreshValidity
+	) {
+		this.accessSecret = accessSecret;
+		this.refreshSecret = refreshSecret;
+		this.accessTokenValidityInMillis = accessValidity * 1000;
+		this.refreshTokenValidityInMillis = refreshValidity * 1000;
+	}
+
+	// 빈이 생성되고 주입을 받은 후에 secret값을 Base64 Decode해서 key 변수에 할당하기 위해
+	@Override
+	public void afterPropertiesSet() {
+		this.accessKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(accessSecret));
+		this.refreshKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshSecret));
+	}
+
+	public String createAccessToken(Authentication authentication) {
+		String authorities = authentication.getAuthorities().stream()
+				.map(GrantedAuthority::getAuthority)
+				.collect(Collectors.joining(","));
+
+		long now = System.currentTimeMillis();
+		return Jwts.builder()
+				.setSubject(authentication.getName())
+				.claim("auth", authorities)
+				.setIssuedAt(new Date(now))
+				.setExpiration(new Date(now + accessTokenValidityInMillis))
+				.signWith(accessKey, SignatureAlgorithm.HS256)
+				.compact();
+	}
+
+	public String createRefreshToken(Authentication authentication) {
+		long now = System.currentTimeMillis();
+		return Jwts.builder()
+				.setSubject(authentication.getName())
+				.setIssuedAt(new Date(now))
+				.setExpiration(new Date(now + refreshTokenValidityInMillis))
+				.signWith(refreshKey, SignatureAlgorithm.HS256)
+				.compact();
+	}
+	// 토큰으로 클레임을 만들고 이를 이용해 유저 객체를 만들어서 최종적으로 authentication 객체를 리턴
+	public Authentication getAuthenticationFromAccessToken(String token) {
+		Claims claims = Jwts.parserBuilder()
+				.setSigningKey(accessKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+
+		Collection<? extends GrantedAuthority> authorities =
+				Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+						.map(SimpleGrantedAuthority::new)
+						.collect(Collectors.toList());
+
+		User principal = new User(claims.getSubject(), "", authorities);
+
+		return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+	}
+
+	public Authentication getAuthenticationFromUserId(Long userId) {
+		// 실제로는 DB 또는 UserDetailsService에서 조회
+		UserDetails userDetails = new User(userId.toString(), "", List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	}
+
+	public Long getUserFromRefreshToken(String token) {
+		Claims claims = getRefreshTokenClaims(token);
+		return Long.valueOf(claims.getSubject()); // subject에 userId가 담겨있다고 가정
+	}
+	public Claims getAccessTokenClaims(String token) {
+		return parseClaims(token, accessKey);
+	}
+
+	public Claims getRefreshTokenClaims(String token) {
+		return parseClaims(token, refreshKey);
+	}
+
+	private Claims parseClaims(String token, SecretKey key) {
+		return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+	}
+	// 토큰의 유효성 검증을 수행
+	public boolean validateAccessToken(String token) {
+		return validateToken(token, accessKey);
+	}
+
+	public boolean validateRefreshToken(String token) {
+		return validateToken(token, refreshKey);
+	}
+
+	private boolean validateToken(String token, SecretKey key) {
+		try {
+			Jwts.parserBuilder()
+					.setSigningKey(key)
+					.build()
+					.parseClaimsJws(token);
+			return true;
+		} catch (SecurityException | MalformedJwtException e) {
+			log.warn("잘못된 JWT 서명입니다: {}", e.getMessage());
+		} catch (ExpiredJwtException e) {
+			log.warn("만료된 JWT 토큰입니다: {}", e.getMessage());
+		} catch (UnsupportedJwtException e) {
+			log.warn("지원하지 않는 JWT 토큰입니다: {}", e.getMessage());
+		} catch (IllegalArgumentException e) {
+			log.warn("JWT claims가 비어있습니다: {}", e.getMessage());
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/RefreshTokenService.java
@@ -1,6 +1,5 @@
 package com.roome.admin.roomeadminbe.global.security.jwt.service;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -8,12 +7,16 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 
 @Service
-@RequiredArgsConstructor
 public class RefreshTokenService {
 
 	private static final Duration REFRES_TOKEN_DURATION = Duration.ofDays(14);
-	@Qualifier("refreshTokenRedisTemplate")
 	private final RedisTemplate<String, String> refreshTokenRedisTemplate;
+
+	public RefreshTokenService(
+			@Qualifier("refreshTokenRedisTemplate") RedisTemplate<String, String> refreshTokenRedisTemplate
+	) {
+		this.refreshTokenRedisTemplate = refreshTokenRedisTemplate;
+	}
 
 	public void saveRefreshToken(Long userId, String refreshToken) {
 		refreshTokenRedisTemplate.opsForValue().set("refresh:" + userId, refreshToken, REFRES_TOKEN_DURATION);

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/RefreshTokenService.java
@@ -1,0 +1,32 @@
+package com.roome.admin.roomeadminbe.global.security.jwt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+	private static final Duration REFRES_TOKEN_DURATION = Duration.ofDays(14);
+	@Qualifier("refreshTokenRedisTemplate")
+	private final RedisTemplate<String, String> refreshTokenRedisTemplate;
+
+	public void saveRefreshToken(Long userId, String refreshToken) {
+		refreshTokenRedisTemplate.opsForValue().set("refresh:" + userId, refreshToken, REFRES_TOKEN_DURATION);
+	}
+
+	public String getRefreshToken(Long userId) {
+		return refreshTokenRedisTemplate.opsForValue().get("refresh:" + userId);
+	}
+
+	// 현재는 만료 시간을 초기화 해주고 있음 -> 서버 관리로 가능함 -> 추후 해당 메서드로  redis 삭제를 해줄지 고민 중
+	public void deleteRefreshToken(Long userId) {
+		refreshTokenRedisTemplate.delete("refresh:" + userId);
+	}
+
+}
+

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/TokenService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/TokenService.java
@@ -40,8 +40,10 @@ public class TokenService {
 
 		// refreshToken rotation
 		String newRefreshToken = tokenProvider.createRefreshToken(authentication);
+
 		refreshTokenService.deleteRefreshToken(userId);
 		refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+
 		// CookieUtil
 		addRefreshTokenCookie(response, newRefreshToken);
 

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/TokenService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/jwt/service/TokenService.java
@@ -1,0 +1,51 @@
+package com.roome.admin.roomeadminbe.global.security.jwt.service;
+
+import com.roome.admin.roomeadminbe.global.security.jwt.provider.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+import static com.roome.admin.roomeadminbe.global.security.util.CookieUtil.addRefreshTokenCookie;
+import static com.roome.admin.roomeadminbe.global.security.util.CookieUtil.extractRefreshTokenFromCookie;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+	private final TokenProvider tokenProvider;
+	private final RefreshTokenService refreshTokenService;
+
+	public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = extractRefreshTokenFromCookie(request);
+
+		if (refreshToken == null || !tokenProvider.validateRefreshToken(refreshToken)) {
+			throw new NoSuchElementException("유효하지 않은 리프레시 토큰입니다.");
+		}
+
+		Long userId = tokenProvider.getUserFromRefreshToken(refreshToken);
+
+		String savedToken = refreshTokenService.getRefreshToken(userId); // Redis나 DB에서 저장된 refreshToken 조회
+		if (!refreshToken.equals(savedToken)) {
+			throw new NoSuchElementException("저장된 토큰과 일치하지 않습니다.");
+		}
+
+		Authentication authentication = tokenProvider.getAuthenticationFromUserId(userId);
+
+		String newAccessToken = tokenProvider.createAccessToken(authentication);
+
+		// refreshToken rotation
+		String newRefreshToken = tokenProvider.createRefreshToken(authentication);
+		refreshTokenService.deleteRefreshToken(userId);
+		refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+		// CookieUtil
+		addRefreshTokenCookie(response, newRefreshToken);
+
+		// accessToken은 응답 헤더에 담아서 보내기
+		response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/model/AdminDetails.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/model/AdminDetails.java
@@ -1,0 +1,63 @@
+package com.roome.admin.roomeadminbe.global.security.model;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import com.roome.admin.roomeadminbe.domain.admin.entity.AdminRole;
+import com.roome.admin.roomeadminbe.domain.admin.entity.Status;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class AdminDetails implements UserDetails {
+
+	private final Admin admin;
+
+	public AdminDetails(Admin admin) {
+		this.admin = admin;
+	}
+
+	public Long getAdminId() {
+		return admin.getAdminId();
+	}
+
+	public AdminRole getAdminRole() {
+		return admin.getAdminRole();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_" + admin.getAdminRole().name()));
+	}
+
+	@Override
+	public String getPassword() {
+		return admin.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return admin.getAdminEmail(); // 이메일을 ID로 쓴다고 가정
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return admin.getStatus() != Status.DORMANT; // 예시
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return Boolean.TRUE.equals(admin.isActivated());
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/service/CustomAdminDetailsService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/service/CustomAdminDetailsService.java
@@ -3,16 +3,13 @@ package com.roome.admin.roomeadminbe.global.security.service;
 import com.roome.admin.roomeadminbe.domain.admin.entity.ActivationStatus;
 import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
 import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
+import com.roome.admin.roomeadminbe.global.security.model.AdminDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,19 +25,11 @@ public class CustomAdminDetailsService implements UserDetailsService {
 				.orElseThrow(() -> new UsernameNotFoundException("관리자 이메일을 찾을 수 없습니다: " + adminEmail));
 	}
 
-	private org.springframework.security.core.userdetails.User createUser(Admin admin) {
+	private AdminDetails createUser(Admin admin) {
 		if (admin.getActivationStatus() != ActivationStatus.ACTIVE) {
 			throw new RuntimeException(admin.getAdminEmail() + " -> 활성화되어 있지 않습니다.");
 		}
 
-		List<GrantedAuthority> grantedAuthorities = List.of(
-				new SimpleGrantedAuthority(admin.getAdminRole().getRoleName())
-		);
-
-		return new org.springframework.security.core.userdetails.User(
-				admin.getAdminEmail(),
-				admin.getPassword(),
-				grantedAuthorities
-		);
+		return new AdminDetails(admin);
 	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/service/CustomAdminDetailsService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/service/CustomAdminDetailsService.java
@@ -1,0 +1,46 @@
+package com.roome.admin.roomeadminbe.global.security.service;
+
+import com.roome.admin.roomeadminbe.domain.admin.entity.ActivationStatus;
+import com.roome.admin.roomeadminbe.domain.admin.entity.Admin;
+import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomAdminDetailsService implements UserDetailsService {
+
+	private final AdminRepository adminRepository;
+
+	@Override
+	@Transactional
+	public UserDetails loadUserByUsername(String adminEmail) throws UsernameNotFoundException {
+		return adminRepository.findByAdminEmail(adminEmail)
+				.map(this::createUser)
+				.orElseThrow(() -> new UsernameNotFoundException("관리자 이메일을 찾을 수 없습니다: " + adminEmail));
+	}
+
+	private org.springframework.security.core.userdetails.User createUser(Admin admin) {
+		if (admin.getActivationStatus() != ActivationStatus.ACTIVE) {
+			throw new RuntimeException(admin.getAdminEmail() + " -> 활성화되어 있지 않습니다.");
+		}
+
+		List<GrantedAuthority> grantedAuthorities = List.of(
+				new SimpleGrantedAuthority(admin.getAdminRole().getRoleName())
+		);
+
+		return new org.springframework.security.core.userdetails.User(
+				admin.getAdminEmail(),
+				admin.getPassword(),
+				grantedAuthorities
+		);
+	}
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/util/CookieUtil.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/util/CookieUtil.java
@@ -32,4 +32,13 @@ public class CookieUtil {
 				.findFirst()
 				.orElse(null);
 	}
+
+	public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(true); // HTTPS 환경일 경우
+		cookie.setPath("/");
+		cookie.setMaxAge(0); // 즉시 만료
+		response.addCookie(cookie);
+	}
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/security/util/CookieUtil.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/security/util/CookieUtil.java
@@ -1,0 +1,35 @@
+package com.roome.admin.roomeadminbe.global.security.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+
+import java.util.Arrays;
+
+public class CookieUtil {
+
+	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+	private static final int REFRESH_TOKEN_EXPIRY = 7 * 24 * 60 * 60; // 7일
+
+	public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+		cookie.setHttpOnly(true); // JS 접근 불가
+		cookie.setSecure(true); // HTTPS에서만 전송
+		cookie.setPath("/"); // 전체 경로에서 유효
+		cookie.setMaxAge(REFRESH_TOKEN_EXPIRY); // 유효 시간 설정
+
+		response.addCookie(cookie);
+	}
+
+	public static String extractRefreshTokenFromCookie(HttpServletRequest request) {
+		if (request.getCookies() == null) {
+			return null;
+		}
+
+		return Arrays.stream(request.getCookies())
+				.filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
+				.map(Cookie::getValue)
+				.findFirst()
+				.orElse(null);
+	}
+}


### PR DESCRIPTION
## 📌 관리자 Auth 관련

### ✅ PR 설명

최고 관리자 - 관리자 초대, 운영자 목록 조회
관리자 - 인증/인가, 정보 변경 등

### 🏗 작업 내용

- [x] 초대 메일 전송 api(로그인 url 추후 논의 예정)
- [x] 임시 비밀번호 요청 api
- [x] 관리자 인증 인가
- [x] 관리자 프로필 조회
- [x] 관리자 정보 변경
- [x] 관리자 로그아웃
- [x] 운영자 목록 조회(QueryDSL 동적 쿼리 적용 - role 별 조회 가능)
- [x] 운영자 권한 삭제
- [x] SpringSecurity 권한 부여

### 📸 테스트 결과 (선택)

> 

### 🔗 관련 이슈 (선택)

> close #1 

### 🚨 참고 사항 (선택)

> 추후 클래스 책임표 전달 예정
> SuperAdmin: Springboot 실행 시 생성(AdminInitializer)
> 
