### PR TITLE
Feat/#29 알림api 추가 구현

### DIFF
--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/controller/NotificationController.java
@@ -6,15 +6,18 @@ import com.roome.admin.roomeadminbe.domain.notification.dto.NotificationRequestD
 import com.roome.admin.roomeadminbe.domain.notification.dto.NotificationResponseDto;
 import com.roome.admin.roomeadminbe.domain.notification.service.NotificationService;
 import com.roome.admin.roomeadminbe.domain.notification.entity.Notification;
+import com.roome.admin.roomeadminbe.global.security.model.AdminDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/admin/notifications")
@@ -26,20 +29,15 @@ public class NotificationController {
     //알림 생성(작성자 본인에게만 생성 + 실시간 푸시)
     @PostMapping
     public ResponseEntity<NotificationResponseDto> createNotification(
-            @RequestBody NotificationRequestDto requestDto){
+            @AuthenticationPrincipal AdminDetails adminDetails, @RequestBody NotificationRequestDto requestDto){
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String email = (auth != null ? auth.getName() : null);
-        if (email == null) throw new RuntimeException("인증 정보가 없습니다.");
+                if(adminDetails == null) throw new RuntimeException("인증 정보가 없습니다.");
 
-        Admin me = adminRepository.findByAdminEmail(email)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 관리자입니다."));
-
-        // 클라이언트로부터 온 adminId는 무시하고, 서버에서 본인 ID로 강제 주입
-        requestDto.setAdminId(me.getAdminId());
+        requestDto.setAdminId(adminDetails.getAdminId());
 
         Notification saved = notificationService.createNotification(requestDto);
         return ResponseEntity.ok(new NotificationResponseDto(saved));
+
     }
 
 
@@ -49,21 +47,25 @@ public class NotificationController {
         return ResponseEntity.ok(notificationService.getAllNotifications());
     }
 
-    /** 3) 특정 관리자 알림 조회(기존 호환용) */
+    /** 3) 특정 관리자 알림 조회 */
     @GetMapping("/{adminId}")
     public ResponseEntity<List<NotificationResponseDto>> getNotificationsByAdminId(
             @PathVariable Long adminId) {
         return ResponseEntity.ok(notificationService.getNotificationsByAdminId(adminId));
     }
 
-    /** 4) 내 알림함 조회(프론트에 권장) */
+    /** 4) 내 알림함 조회 */
     @GetMapping("/me")
-    public ResponseEntity<List<NotificationResponseDto>> getMyNotifications() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String email = (auth != null ? auth.getName() : null);
-        if (email == null) throw new RuntimeException("인증 정보가 없습니다.");
+    public ResponseEntity<Map<String, Object>> getMyNotifications(
+            @AuthenticationPrincipal AdminDetails adminDetails
+    ) {
 
-        return ResponseEntity.ok(notificationService.getMyNotificationsByEmail(email));
+        if (adminDetails == null) {
+            throw new RuntimeException("인증 정보가 없습니다.");
+        }
+
+        String email = adminDetails.getUsername();
+        return ResponseEntity.ok(notificationService.getMineGroupedWithSummary(email));
     }
 
     /** 5) SSE 구독: 본인 채널만 구독 가능 */
@@ -83,16 +85,45 @@ public class NotificationController {
         // 등록 + INIT 전송 + 타임아웃/정리는 서비스에서 처리
         return notificationService.subscribe(adminId);
     }
+    //전체 읽음 조회
+    @PutMapping("/allread")
+    public ResponseEntity<Map<String, String>> markAllAsRead(
+            @RequestBody Map<String, Long> body,
+            @AuthenticationPrincipal AdminDetails adminDetails
+    ){
+        if (adminDetails == null) throw new RuntimeException("인증 정보가 없습니다.");
 
-    // (선택) 구독 간편 버전: 파라미터 없이 '내 채널' 자동 구독하고 싶다면 아래를 사용
-    // @GetMapping(value = "/subscribe/me", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    // public SseEmitter subscribeMe() {
-    //     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    //     String email = (auth != null ? auth.getName() : null);
-    //     if (email == null) throw new RuntimeException("인증 정보가 없습니다.");
-    //
-    //     Admin me = adminRepository.findByAdminEmail(email)
-    //             .orElseThrow(() -> new RuntimeException("존재하지 않는 관리자입니다."));
-    //     return notificationService.subscribe(me.getAdminId());
-    // }
+        Long adminId = body.get("adminId");
+        String message = notificationService.markAllAsReadByAdminId(adminId);
+
+        return ResponseEntity.ok(Map.of("message", message));
+    }
+
+    //단일 읽음 조회
+   @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Map<String, String>> markAsRead(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal AdminDetails adminDetails
+   ){
+        if (adminDetails == null){
+            throw new RuntimeException("인증 정보가 없습니다.");
+        }
+        String email = adminDetails.getUsername();
+        notificationService.markAsRead(notificationId, email);
+        return ResponseEntity.ok(Map.of("message","알림이 읽음 처리되었습니다."));
+   }
+
+   //안읽음조회
+   @GetMapping("/unread")
+    public Map<String, Object> getUnread(@AuthenticationPrincipal AdminDetails adminDetails){
+        String email = adminDetails.getUsername();
+        return notificationService.getUnreadGrouped(email);
+   }
+
+   //긴급 조회
+    @GetMapping("/urgent")
+    public Map<String, Object> getUrgent(@AuthenticationPrincipal AdminDetails adminDetails){
+        String email = adminDetails.getUsername();
+        return notificationService.getUrgentGrouped(email);
+    }
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,40 @@ package com.roome.admin.roomeadminbe.domain.notification.repository;
 
 import com.roome.admin.roomeadminbe.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    //전체 읽음
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+    UPDATE bo_notifications n
+    JOIN admin_notification an ON an.notification_id = n.notification_id
+    SET n.is_read = 1
+    WHERE an.admin_id = :adminId AND n.is_read = 0
+    """, nativeQuery = true)
+    int markAllAsReadByAdminId(@Param("adminId") Long adminId);
+
+    // 배지 갱신 등에서 사용할 미읽음 카운트
+    @Query(value = """
+    SELECT COUNT(*)
+    FROM bo_notifications n
+    JOIN admin_notification an ON an.notification_id = n.notification_id
+    WHERE an.admin_id = :adminId AND n.is_read = 0
+    """, nativeQuery = true)
+    long countUnreadByAdminId(@Param("adminId") Long adminId);
+
+
+    List<Notification> findByIsReadFalseOrderByCreatedAtDesc();
+
+    List<Notification> findByIsUrgentTrueOrderByCreatedAtDesc();
+
+    List<Notification> findAllByOrderByCreatedAtDesc();
+    // 스키마 정리되면 다음과 같은 쿼리 메서드 추가 예정:
+    // List<Notification> findAllByAdminEmail(String adminEmail);
+    // 이후 소유자 검증 추가 시 예시:
+    // Optional<Notification> findByNotificationIdAndAdmin_Email(Long id, String email);
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/service/NotificationService.java
@@ -9,11 +9,16 @@ import com.roome.admin.roomeadminbe.domain.notification.entity.AdminNotification
 import com.roome.admin.roomeadminbe.domain.notification.repository.NotificationRepository;
 import com.roome.admin.roomeadminbe.domain.notification.repository.AdminNotificationRepository;
 import com.roome.admin.roomeadminbe.domain.notification.type.NotificationCategory;
+import com.roome.admin.roomeadminbe.global.exception.BusinessException;
+import com.roome.admin.roomeadminbe.global.exception.enumeration.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -78,11 +83,118 @@ public class NotificationService {
                 .map(NotificationResponseDto::new)
                 .collect(Collectors.toList());
     }
-    // (편의) 이메일로 "내 알림 전부" 조회
+    // "내 알림 전부" 조회
     public List<NotificationResponseDto> getMyNotificationsByEmail(String email) {
         Admin me = adminRepository.findByAdminEmail(email)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 관리자입니다."));
         return getNotificationsByAdminId(me.getAdminId());
+    }
+
+    // 안 읽은 조회 목록 (관리자 범위)
+    @Transactional(readOnly = true)
+    public Map<String, Object> getUnreadGrouped(String adminEmail){
+        Admin me = adminRepository.findByAdminEmail(adminEmail)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 관리자입니다."));
+        // 관리자 범위로 가져온 뒤, 메모리에서 unread만 필터
+        List<Notification> list = adminNotificationRepository.findNotificationsByAdminId(me.getAdminId())
+                .stream().filter(n -> !n.isRead())
+                .sorted(Comparator.comparing(Notification::getCreatedAt).reversed())
+                .toList();
+        return toGroupedResponse(list);
+    }
+
+    private static final DateTimeFormatter ISO_IN_UTC = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    private Map<String, Object> toGroupedResponse(List<Notification> list){
+        //totalCount
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("totalCount", list.size());
+
+        //날짜별 그룹
+        Map<String, List<Map<String, Object>>> grouped = list.stream()
+                .map(this::toItem)
+                .collect(Collectors.groupingBy(
+                    m -> (String) m.get("dateKey"),
+                    LinkedHashMap::new,
+                    Collectors.toList()
+                ));
+        //response 구조로 넣기
+        grouped.forEach((date,items) -> {
+            items.forEach(it -> it.remove("dateKey"));
+            result.put(date,items);
+        });
+
+        return result;
+    }
+
+    private Map<String, Object> toItem(Notification n){
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("notificationId", n.getNotificationId());
+        m.put("category", n.getCategory().name());
+        m.put("message", n.getNotificationContent());
+        m.put("isRead", n.isRead());
+        m.put("isUrgent", n.isUrgent());
+
+        String ts = n.getCreatedAt().atOffset(ZoneOffset.UTC).format(ISO_IN_UTC);
+        m.put("timestamp", ts);
+
+        m.put("dateKey", n.getCreatedAt().toLocalDate().toString());
+        return m;
+    }
+
+    // 긴급 목록 조회 (관리자 범위 + urgent만)
+    @Transactional(readOnly = true)
+    public Map<String, Object> getUrgentGrouped(String adminEmail){
+        Admin me = adminRepository.findByAdminEmail(adminEmail)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 관리자입니다."));
+        //나에게 배정된 알림 중 "긴급"만!
+        List<Notification> list = adminNotificationRepository.findNotificationsByAdminId(me.getAdminId())
+                .stream()
+                .filter(Notification::isUrgent) // 긴급 "전체"
+        //        .stream().filter(n -> n.isUrgent())//이건 미읽음 긴급
+                .sorted(Comparator.comparing(Notification::getCreatedAt).reversed())
+                .toList();
+        return toGroupedResponse(list);
+    }
+
+    //내 알림함 구분(전체,안읽음,긴급안읽음)
+    @Transactional (readOnly = true)
+    public Map<String, Object> getMineGroupedWithSummary(String adminEmail){
+        //1) 전체목록
+        List<Notification> all = notificationRepository.findAllByOrderByCreatedAtDesc();
+
+        //2) 카운트 먼저 계산
+        long total = all.size();
+        long unread = all.stream().filter(n -> !n.isRead()).count();
+        long urgentUnread = all.stream().filter(n -> !n.isRead() && n.isUrgent()).count();
+
+        //3) 응답 맵을 카운트 먼저 삽입 후 생성(삽입 순서 보장 위해 LinkedHashMap 사용)
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("totalCount", total);
+        result.put("unreadCount", unread);
+        result.put("urgentCount", urgentUnread);
+
+        //4) 날짜별 그룹 만든 후 카운트 뒤에 붙이기
+        Map<String, List<Map<String, Object>>> grouped = groupByDate(all);
+        //toItem에서 내부용으로 넣은 dateKey 제거하기
+        grouped.forEach((date, items) -> {
+            items.forEach(it -> it.remove("dateKey"));
+            result.put(date, items);
+        });
+
+        return result;
+    }
+
+
+    //내 알림함 응답 시 날짜별 그룹
+    private Map<String, List<Map<String, Object>>> groupByDate(List<Notification> list){
+        return list.stream()
+                .map(this::toItem)
+                .collect(Collectors.groupingBy(
+                        m -> (String) m.get("dateKey"),
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
     }
 
     // *****생성(작성자)*****
@@ -149,9 +261,29 @@ public class NotificationService {
         dto.setNotificationTitle(title);
         dto.setNotificationContent(content);
         dto.setCategory(category);
-        // boolean 필드 셋터가 setUrgent(...) 또는 setIsUrgent(...) 중 무엇인지 DTO에 맞춰 사용하세요.
         dto.setUrgent(isUrgent);
 
         return createNotification(dto);
+    }
+
+    //단일 읽음 처리
+    @Transactional
+    public NotificationResponseDto markAsRead(Long notificationId, String adminEmail){
+        Notification n = notificationRepository.findById(notificationId)
+                .orElseThrow(()-> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        //admin 연관/컬럼 복구 후 아래 한 줄 활성화 (소유자 검증)
+        // if (!n.getAdmin().getEmail().equals(adminEmail)) throw new BusinessException(ErrorCode.FORBIDDEN);
+
+        if (!n.isRead()){
+            n.setRead(true);
+        }
+        return new NotificationResponseDto(n);
+    }
+    // 전체 읽음 처리
+    @Transactional
+    public String markAllAsReadByAdminId(Long adminId){
+        if (adminId == null) throw new IllegalArgumentException("adminId가 필요합니다.");
+        notificationRepository.markAllAsReadByAdminId(adminId);
+        return "전체 알림이 읽음 처리되었습니다.";
     }
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/global/exception/enumeration/ErrorCode.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/global/exception/enumeration/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     USER_NOT_FOUND("사용자 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     PASSWORD_NOT_MATCHES("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_INPUT_VALUE("유효하지 않은 요청값입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_JSON("json 파싱에 실패했습니다.", HttpStatus.BAD_REQUEST);
+    INVALID_JSON("json 파싱에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    NOTIFICATION_NOT_FOUND("알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND );
 
     private final String message;
     private final HttpStatus status;


### PR DESCRIPTION
## 📌 Feat/#29 알림api 추가 구현

### ✅ PR 설명
알림api 추가 구현

### 🏗 작업 내용

- [ ] ErrorCode.java : 알림 기능 ErrorCode 추가
- [ ] NotificationController.java :  @AuthenticationPrincipal 코드 구현 수정
- [ ] NotificationRepository.java :  나에게 온 알림함 API 구현
- [ ] NotificationService.java : 안읽은 조회목록API 수정 및 긴급목록조회, 알림함구분, 읽음처리(단일,전체) API구현

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> close #29 

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
