### PR TITLE
✨ feat: SSE 로직 서비스 분리 + 자동삭제 스케줄러 추가 구현

### DIFF
--- a/src/main/java/com/roome/admin/roomeadminbe/RoomeAdminBeApplication.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/RoomeAdminBeApplication.java
@@ -2,7 +2,9 @@ package com.roome.admin.roomeadminbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class RoomeAdminBeApplication {
 

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/controller/NotificationController.java
@@ -5,21 +5,26 @@ import com.roome.admin.roomeadminbe.domain.admin.repository.AdminRepository;
 import com.roome.admin.roomeadminbe.domain.notification.dto.NotificationRequestDto;
 import com.roome.admin.roomeadminbe.domain.notification.dto.NotificationResponseDto;
 import com.roome.admin.roomeadminbe.domain.notification.service.NotificationService;
-import com.roome.admin.roomeadminbe.domain.notification.entity.Notification;
+import com.roome.admin.roomeadminbe.domain.notification.service.SseService;
 import com.roome.admin.roomeadminbe.global.exception.BusinessException;
 import com.roome.admin.roomeadminbe.global.exception.enumeration.ErrorCode;
 import com.roome.admin.roomeadminbe.global.security.model.AdminDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import jakarta.servlet.http.HttpServletRequest;
+
 
 @RestController
 @RequestMapping("/api/admin/notifications")
@@ -27,6 +32,9 @@ import java.util.Map;
 public class NotificationController {
     private final NotificationService notificationService;
     private final AdminRepository adminRepository;
+    private static final Logger log = LoggerFactory.getLogger(NotificationController.class);
+    private final SseService sseService;
+
 
     //알림 생성(작성자 본인에게만 생성 + 실시간 푸시)
     @PostMapping
@@ -73,23 +81,18 @@ public class NotificationController {
         return ResponseEntity.ok(notificationService.getMineGroupedWithSummary(email));
     }
 
+
     /** 5) SSE 구독: 본인 채널만 구독 가능 */
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@AuthenticationPrincipal AdminDetails adminDetails,
-                                @RequestParam("adminId") Long adminId) {
-        String email = adminDetails.getUsername(); //email->username을 가져옴
-        if (email == null) throw new RuntimeException("인증 정보가 없습니다.");
-
-        Admin me = adminRepository.findByAdminEmail(email)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 관리자입니다."));
-
-        if (!me.getAdminId().equals(adminId)) {
-            throw new RuntimeException("본인 채널만 구독할 수 있습니다.");
+    public SseEmitter subscribe(@AuthenticationPrincipal AdminDetails admin) {
+        if (admin == null || admin.getAdminId() == null){
+            throw new RuntimeException("인증 정보가 없습니다.");
         }
 
         // 등록 + INIT 전송 + 타임아웃/정리는 서비스에서 처리
-        return notificationService.subscribe(adminId);
+        return sseService.subscribe(admin.getAdminId());
     }
+
     //전체 읽음 처리
     @PutMapping("/allread")
     public ResponseEntity<Map<String, String>> markAllAsRead(

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,27 @@
+package com.roome.admin.roomeadminbe.domain.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class EmitterRepository {
+
+    //한 관리자 = 연결 1개
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(Long adminId, SseEmitter emitter){
+        emitters.put(adminId, emitter);
+        return emitter;
+    }
+
+    public Optional<SseEmitter>get(Long adminId){
+        return Optional.ofNullable(emitters.get(adminId));
+    }
+    public void delete(Long adminId){
+        emitters.remove(adminId);
+    }
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/service/NotificationService.java
@@ -14,6 +14,8 @@ import com.roome.admin.roomeadminbe.global.exception.enumeration.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
@@ -22,6 +24,17 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.time.ZoneId;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+
+
 
 @Service
 @RequiredArgsConstructor
@@ -31,40 +44,17 @@ public class NotificationService {
     private final AdminNotificationRepository adminNotificationRepository;
     private final AdminRepository adminRepository;
 
-    // 한 관리자당 SSE 연결 1개만 유지
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
-    // ******SSE 채널연결 + 전송******
-    //구독 : 새 연결 시 기존 연결은 종료하고 교체
+    private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private final SseService sseService;
+
+    // 구독은 SseService로 위임
     public SseEmitter subscribe(Long adminId) {
-        SseEmitter emitter = new SseEmitter(30L * 60 * 1000L); //30분
-
-        // 이전 연결이 있었다면 종료
-        SseEmitter old = emitters.put(adminId, emitter);
-        if (old != null) {
-            try { old.complete(); } catch (Exception ignore) {}
-        }
-
-        // 연결 직후 INIT 한 번 전송 (스트림 활성화)
-        try { emitter.send(SseEmitter.event().name("INIT").data("ok")); } catch (Exception ignore) {}
-
-        // 끊기면 맵에서 제거
-        emitter.onCompletion(() -> emitters.remove(adminId, emitter));
-        emitter.onTimeout(() -> emitters.remove(adminId, emitter));
-
-        return emitter;
+        return sseService.subscribe(adminId);
     }
-
-    // 해당 관리자 전송
-    public void sendToClient(Long adminId, NotificationResponseDto dto)    {
-        SseEmitter emitter = emitters.get(adminId);
-        if (emitter == null) return;
-
-        try {
-            emitter.send(SseEmitter.event().name("notification").data(dto));
-        } catch (Exception ex) {
-            // 실패하면 정리
-            emitters.remove(adminId, emitter);
-        }
+    // 전송도 SseService로 위임 (기존 메서드 시그니처 유지)
+    public void sendToClient(Long adminId, NotificationResponseDto dto){
+        sseService.send(adminId, dto);
     }
 
     //*********공통 : 정렬/타입존 유틸
@@ -214,12 +204,18 @@ public class NotificationService {
                 AdminNotification.builder().admin(me).notification(saved).build()
         );
 
-        sendToClient(me.getAdminId(), new NotificationResponseDto(saved));
+        //sendToClient(me.getAdminId(), new NotificationResponseDto(saved));
+        //커밋 후 전송
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                sendToClient(me.getAdminId(), new NotificationResponseDto(saved));
+            }
+        });
         return new NotificationResponseDto(saved);
     }
 
-    // (편의) 내부 도메인에서 이메일만 알고 바로 생성하고 싶을 때
-    public Notification createForAuthorEmail(String email,
+    public NotificationResponseDto publishForSelf(String email,
                                              String title,
                                              String content,
                                              NotificationCategory category,
@@ -231,9 +227,7 @@ public class NotificationService {
         dto.setCategory(category);
         dto.setUrgent(isUrgent);
 
-        NotificationResponseDto res = createForMe(email, dto);
-        return notificationRepository.findById(res.getNotificationId())
-                .orElseThrow(() -> new RuntimeException("생성된 알림을 찾을 수 없습니다."));
+        return createForMe(email, dto);
     }
 
     //******읽음********
@@ -254,4 +248,44 @@ public class NotificationService {
         notificationRepository.markAllAsReadByAdminId(me.getAdminId());
         return "전체 알림이 읽음 처리되었습니다.";
     }
+
+    //*****스케줄러/자동삭제*******
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Value("${notification.cleanup.enabled:false}")
+    private boolean cleanupEnabled;
+
+    @Value("${notification.cleanup.retention-days:30}")
+    private int retentionDays;
+
+    // 매월 1일 04:30 KST (yml 값 사용, 일관성 유지)
+    @Scheduled(cron = "${notification.cleanup.cron}", zone = "Asia/Seoul")
+    public void scheduledCleanup() {
+        if (!cleanupEnabled) return;
+        LocalDateTime cutoff = LocalDateTime.now(KST).minusDays(retentionDays);
+        CleanupResult r = cleanupOlderThan(cutoff);
+        log.info("[NotificationCleanup] cutoff={}, joinDeleted={}, notifDeleted={}",
+                cutoff, r.joinDeleted(), r.notifDeleted());
+    }
+
+    @Transactional
+    public CleanupResult cleanupOlderThan(LocalDateTime cutoff) {
+        long joinDeleted = em.createQuery("""
+            DELETE FROM AdminNotification an
+            WHERE an.notification.createdAt < :cutoff
+        """).setParameter("cutoff", cutoff).executeUpdate();
+
+        long notifDeleted = em.createQuery("""
+            DELETE FROM Notification n
+            WHERE n.createdAt < :cutoff
+        """).setParameter("cutoff", cutoff).executeUpdate();
+
+        return new CleanupResult(cutoff, joinDeleted, notifDeleted);
+    }
+
+    public record CleanupResult(LocalDateTime cutoff, long joinDeleted, long notifDeleted) {}
 }
+
+

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/service/SseService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/service/SseService.java
@@ -1,0 +1,71 @@
+package com.roome.admin.roomeadminbe.domain.notification.service;
+
+import com.roome.admin.roomeadminbe.domain.notification.dto.NotificationResponseDto;
+import com.roome.admin.roomeadminbe.domain.notification.repository.EmitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+
+@Service
+@RequiredArgsConstructor
+public class SseService {
+
+    private static final Logger log = LoggerFactory.getLogger(SseService.class);
+    private static final long TIMEOUT = 30 * 60 * 1000L; //30분
+
+    private final EmitterRepository emitterRepository;
+
+    /**
+     * 한 관리자 = 연결 1개. 기존 연결이 있으면 닫고 교체
+     */
+    public SseEmitter subscribe(Long adminId) {
+        emitterRepository.get(adminId).ifPresent(old -> {
+            try {
+                old.complete();
+            } catch (Exception ignore) {
+            }
+            emitterRepository.delete(adminId);
+            log.info("[SSE] existing emitter closed (adminId={})", adminId);
+        });
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        emitter.onTimeout(() -> cleanup(adminId, "timeout"));
+        emitter.onCompletion(() -> cleanup(adminId, "completed"));
+        emitter.onError(ex -> cleanup(adminId, "error:" + ex.getClass().getSimpleName()));
+
+        emitterRepository.save(adminId, emitter);
+
+        // 초기 코멘트(연결 확인 및 일부 프록시 버퍼링 회피)
+        try { emitter.send(SseEmitter.event().comment("connected")); } catch (IOException ignore) {}
+        return emitter;
+    }
+    /** 특정 관리자에게만 전송 (브로드캐스트 아님) */
+    public void send(Long adminId, NotificationResponseDto dto) {
+        emitterRepository.get(adminId).ifPresentOrElse(emitter -> {
+            try {
+                SseEmitter.SseEventBuilder event = SseEmitter.event()
+                        .id(UUID.randomUUID().toString())
+                        .name("NOTIFICATION")
+                        .data(dto, MediaType.APPLICATION_JSON)
+                        .reconnectTime(3000);
+                emitter.send(event);
+            } catch (IOException | IllegalStateException e) {
+                try { emitter.completeWithError(e); } catch (Exception ignore) {}
+                cleanup(adminId, "send-failed");
+            }
+        }, () -> log.info("[SSE] no active emitter (adminId={})", adminId));
+    }
+    public void sendToClient(Long adminId, NotificationResponseDto dto) {
+        send(adminId, dto);
+    }
+    private void cleanup(Long adminId, String reason) {
+        emitterRepository.delete(adminId);
+        log.info("[SSE] cleaned emitter (adminId={}, reason={})", adminId, reason);
+    }
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/notification/type/NotificationCategory.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/notification/type/NotificationCategory.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 public enum NotificationCategory {
 
     EVENT("이벤트 관리"),
-    SYSTEM("운영시스템 / 배포현황"),
-    NOTICE("공지사항");
+    SYSTEM("운영시스템 관련"),
+    CICD("배포/자동화 관련"),
+    USER("사용자 활동 관련"),
+    ETC("기타");
 
     private final String displayName;
 


### PR DESCRIPTION
## 📌✨ feat: SSE 서비스 분리 + 자동삭제 스케줄러 추가 구현

### ✅ PR 설명

SSE 서비스 분리 + 자동삭제 스케줄러 추가 구현

### 🏗 작업 내용

- [ ] 컨트롤러의 SSE 관리 코드 제거
- [ ] SseService로 subscribe/send 위임
- [ ] 데이터 자동삭제 스케줄러 추가(매월 1일 AM4:30 삭제 실행)
- [ ] enum category 추가

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> close #39 

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
