### PR TITLE
GA 작업을 위한 중간 pr

### DIFF
--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/entity/GaEventDaily.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/entity/GaEventDaily.java
@@ -23,6 +23,10 @@ public class GaEventDaily {
     private String featureName;
     private String customUserId;  // 프론트에서 넘긴 사용자 식별자
 
+    private String eventCategory;
+    private String source; // 유입 소스 URL
+    private String medium; // 유입 매체
+
     private Long eventCount;      // 이벤트 발생 횟수
     private Long engagementDuration; // userEngagementDuration 합산값
     private Long durationSec;

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/entity/GaEventDaily.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/entity/GaEventDaily.java
@@ -33,7 +33,6 @@ public class GaEventDaily {
 
     private LocalDateTime eventAt;
     private LocalDateTime collectedAt; // 백엔드에서 수집 시각
-    private String source;        // URL
 
     public void update(Long eventCount, Long durationSec, LocalDateTime eventAt, LocalDateTime collectedAt) {
         this.eventCount = eventCount;

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/entity/GaUserStat.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/entity/GaUserStat.java
@@ -1,0 +1,31 @@
+package com.roome.admin.roomeadminbe.domain.ga4.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.checkerframework.checker.units.qual.A;
+import org.checkerframework.checker.units.qual.N;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "ga_user_stat")
+public class GaUserStat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long dau;
+    private Long mau;
+
+    private LocalDate statDate;
+    private LocalDateTime collectedAt;
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/repository/GaUserStatRepository.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/repository/GaUserStatRepository.java
@@ -1,0 +1,7 @@
+package com.roome.admin.roomeadminbe.domain.ga4.repository;
+
+import com.roome.admin.roomeadminbe.domain.ga4.entity.GaUserStat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GaUserStatRepository extends JpaRepository<GaUserStat,Long> {
+}

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/scheduler/GaDailyJob.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/scheduler/GaDailyJob.java
@@ -17,14 +17,15 @@ public class GaDailyJob {
     private final GaAggregationService aggregationService;
 
     // 매일 새벽 2시(KST) 전일 데이터 수집
-    @Scheduled(cron = "0 30 18 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 20 6 * * *", zone = "Asia/Seoul")
     public void collectYesterday() {
         LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
         gaEventService.collectDailyEvents(yesterday);
+        gaEventService.collectUserStats(yesterday);
     }
 
     // 매일 새벽 3시 KST, 전일 데이터 집계
-    @Scheduled(cron = "0 35 18 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 25 6 * * *", zone = "Asia/Seoul")
     public void aggregateYesterday() {
         LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
         aggregationService.aggregate(yesterday);

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/service/GaEventCollectorService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/service/GaEventCollectorService.java
@@ -2,7 +2,9 @@ package com.roome.admin.roomeadminbe.domain.ga4.service;
 
 import com.google.analytics.data.v1beta.*;
 import com.roome.admin.roomeadminbe.domain.ga4.entity.GaEventDaily;
+import com.roome.admin.roomeadminbe.domain.ga4.entity.GaUserStat;
 import com.roome.admin.roomeadminbe.domain.ga4.repository.GaEventDailyRepository;
+import com.roome.admin.roomeadminbe.domain.ga4.repository.GaUserStatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +25,7 @@ public class GaEventCollectorService {
 
     private final BetaAnalyticsDataClient analyticsDataClient;
     private final GaEventDailyRepository dailyRepository;
+    private final GaUserStatRepository gaUserStatRepository;
 
     @Value("${ga4.property-id}")
     private String propertyId;
@@ -37,6 +40,9 @@ public class GaEventCollectorService {
                 .addDimensions(Dimension.newBuilder().setName("eventName"))
                 .addDimensions(Dimension.newBuilder().setName("customEvent:custom_user_id"))
                 .addDimensions(Dimension.newBuilder().setName("customEvent:timestamp")) // 프론트에서 보낸 timestamp
+                .addDimensions(Dimension.newBuilder().setName("customEvent:event_category")) // custom
+                .addDimensions(Dimension.newBuilder().setName("sessionSource"))              // 기본 제공
+                .addDimensions(Dimension.newBuilder().setName("sessionMedium"))
                 .addMetrics(Metric.newBuilder().setName("eventCount"))
                 .addMetrics(Metric.newBuilder().setName("customEvent:duration_sec"))
                 .build();
@@ -48,6 +54,9 @@ public class GaEventCollectorService {
                 String eventName = row.getDimensionValues(0).getValue();
                 String customUserId = row.getDimensionValues(1).getValue();
                 String timestampStr = row.getDimensionValues(2).getValue();
+                String  eventCategory = row.getDimensionValues(3).getValue();
+                String source = row.getDimensionValues(4).getValue();
+                String medium = row.getDimensionValues(5).getValue();
                 LocalDateTime eventAt = null;
                 String featureName = null;
                 if (eventName.contains("usage")) {
@@ -82,6 +91,9 @@ public class GaEventCollectorService {
                             .customUserId(customUserId)
                             .eventCount(eventCount)
                             .durationSec(durationSec)
+                            .eventCategory(eventCategory)
+                            .source(source)
+                            .medium(medium)
                             .eventAt(eventAt)
                             .collectedAt(LocalDateTime.now())
                             .build();
@@ -97,6 +109,37 @@ public class GaEventCollectorService {
         }
 
         log.info("GA 이벤트 데이터 저장 완료: {} rows (statDate={})", response.getRowsCount(), date);
+    }
+
+    @Transactional
+    public void collectUserStats(LocalDate date) {
+        RunReportRequest request = RunReportRequest.newBuilder()
+                .setProperty("properties/" + propertyId)
+                .addDateRanges(DateRange.newBuilder()
+                        .setStartDate(date.toString())
+                        .setEndDate(date.toString()))
+                .addDimensions(Dimension.newBuilder().setName("date"))
+                .addMetrics(Metric.newBuilder().setName("activeUsers"))      // dau
+                .addMetrics(Metric.newBuilder().setName("active28DayUsers")) // mau
+                .build();
+
+        RunReportResponse response = analyticsDataClient.runReport(request);
+
+        for (Row row : response.getRowsList()) {
+            Long dau = parseLongSafe(row.getMetricValues(0).getValue());
+            Long mau = parseLongSafe(row.getMetricValues(1).getValue());
+
+            GaUserStat stat = GaUserStat.builder()
+                    .statDate(date)
+                    .dau(dau)
+                    .mau(mau)
+                    .collectedAt(LocalDateTime.now())
+                    .build();
+
+            gaUserStatRepository.save(stat);
+
+            log.info("Saved UserStat - date={}, dau={}, mau={}", date, dau, mau);
+        }
     }
 
     private Long parseLongSafe(String value) {


### PR DESCRIPTION
## 📌 GA 작업을 위한 중간 pr

### ✅ PR 설명

방문자 수 테이블 생성해서 관리 GaUserStat 확인

### 🏗 작업 내용

- [ ] GaUserStat 생성
- [ ] GA 기본 정보 백엔드 api 로 GaUserStat에 저장하도록 구현

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> #25 

### 🚨 참고 사항 (선택)

> ERD 추가 완료 확인 바랍니다.
