### PR TITLE
🚨 Fix: 서비스 사용 지표 카드, 차트, 요약 조회 수정

### DIFF
--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/repository/GaEventDailyRepositoryImpl.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/repository/GaEventDailyRepositoryImpl.java
@@ -8,12 +8,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.roome.admin.roomeadminbe.domain.ga4.dto.response.ActivityHourResponse;
 import com.roome.admin.roomeadminbe.domain.ga4.dto.response.ChartResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -78,7 +78,7 @@ public class GaEventDailyRepositoryImpl implements GaEventDailyRepositoryCustom 
                 .from(gaEventDaily)
                 .where(
                         gaEventDaily.eventName.eq("first_visit"),
-                        gaEventDaily.statDate.eq(LocalDate.now()) // 오늘 날짜
+                        gaEventDaily.statDate.eq(LocalDate.now().minusDays(1)) // 오늘 날짜
                 )
                 .fetchOne();
 
@@ -92,7 +92,7 @@ public class GaEventDailyRepositoryImpl implements GaEventDailyRepositoryCustom 
                 .from(gaEventDaily)
                 .where(
                         gaEventDaily.eventName.eq("first_visit"),
-                        gaEventDaily.statDate.eq(LocalDate.now()) // 오늘 날짜
+                        gaEventDaily.statDate.eq(LocalDate.now().minusDays(1)) // 오늘 날짜
                 )
                 .fetchOne();
 
@@ -103,7 +103,7 @@ public class GaEventDailyRepositoryImpl implements GaEventDailyRepositoryCustom 
                 .from(gaEventDaily)
                 .where(
                         gaEventDaily.eventName.eq("first_visit"),
-                        gaEventDaily.statDate.eq(LocalDate.now().minusDays(1)) // 어제 날짜
+                        gaEventDaily.statDate.eq(LocalDate.now().minusDays(2)) // 어제 날짜
                 )
                 .fetchOne();
 
@@ -138,35 +138,45 @@ public class GaEventDailyRepositoryImpl implements GaEventDailyRepositoryCustom 
 
     @Override
     public List<ChartResponse> getInflowChart() {
+        List<ChartResponse> result = new ArrayList<>();
         LocalDate today = LocalDate.now();
 
         // 오늘 ~ 6일 전까지 날짜 리스트
-        List<LocalDate> targets = new ArrayList<>();
-        for (int i = 0; i <= 6; i++) {
+        for (int i = 1; i <= 7; i++) {
+            List<LocalDate> targets = new ArrayList<>();
             targets.add(today.minusDays(i));
+
+            NumberExpression<Long> sumEventCount = gaEventDaily.eventCount.sum();
+
+            List<Tuple> rows = jpaQueryFactory
+                    .select(gaEventDaily.statDate, sumEventCount)
+                    .from(gaEventDaily)
+                    .where(
+                            gaEventDaily.eventName.eq("first_visit"),
+                            gaEventDaily.statDate.in(targets)
+                    )
+                    .groupBy(gaEventDaily.statDate)
+                    .orderBy(gaEventDaily.statDate.asc())
+                    .fetch();
+
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+            List<ChartResponse> oneRow = rows.stream()
+                    .map(t -> new ChartResponse(
+                            t.get(gaEventDaily.statDate).format(fmt),   // xLabels
+                            String.valueOf(t.get(sumEventCount))        // value
+                    ))
+                    .toList();
+
+            if (ObjectUtils.isEmpty(oneRow)) {
+                result.add(new ChartResponse(today.minusDays(i).format(fmt)
+                        , String.valueOf(0)));
+            } else {
+                result.addAll(oneRow);
+            }
+
         }
-
-        NumberExpression<Long> sumEventCount = gaEventDaily.eventCount.sum();
-
-        List<Tuple> rows = jpaQueryFactory
-                .select(gaEventDaily.statDate, sumEventCount)
-                .from(gaEventDaily)
-                .where(
-                        gaEventDaily.eventName.eq("first_visit"),
-                        gaEventDaily.statDate.in(targets)
-                )
-                .groupBy(gaEventDaily.statDate)
-                .orderBy(gaEventDaily.statDate.asc())
-                .fetch();
-
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-        return rows.stream()
-                .map(t -> new ChartResponse(
-                        t.get(gaEventDaily.statDate).format(fmt),   // xLabels
-                        String.valueOf(t.get(sumEventCount))        // value
-                ))
-                .toList();
+        return result;
     }
 
     @Override
@@ -214,44 +224,46 @@ public class GaEventDailyRepositoryImpl implements GaEventDailyRepositoryCustom 
     @Override
     public List<ChartResponse> getReferralChart() {
         LocalDate today = LocalDate.now();
-        DateTimeFormatter ymFmt = DateTimeFormatter.ofPattern("yyyy-MM");
-
         List<ChartResponse> results = new ArrayList<>();
 
-        // 0 ~ 6개월 전까지 반복
-        for (int i = 0; i <= 6; i++) {
-            LocalDate startOfMonth = today.withDayOfMonth(1).minusMonths(i);
-            LocalDate startOfNextMonth = startOfMonth.plusMonths(1);
+        LocalDate startDate = today.minusDays(1);
+        LocalDate endDate = today.minusDays(7);
 
-            NumberExpression<Long> sumEventCount = gaEventDaily.eventCount.sum();
+        NumberExpression<Long> sumEventCount = gaEventDaily.eventCount.sum();
 
-            Tuple row = jpaQueryFactory
-                    .select(gaEventDaily.source, sumEventCount)
-                    .from(gaEventDaily)
-                    .where(
-                            gaEventDaily.eventName.eq("traffic_source"),
-                            gaEventDaily.statDate.goe(startOfMonth),
-                            gaEventDaily.statDate.lt(startOfNextMonth)
-                    )
-                    .groupBy(gaEventDaily.source)
-                    .orderBy(sumEventCount.desc())
-                    .fetchFirst(); // limit 1
+        List<Tuple> rows = jpaQueryFactory
+                .select(gaEventDaily.source, sumEventCount)
+                .from(gaEventDaily)
+                .where(
+                        gaEventDaily.eventName.eq("traffic_source"),
+                        gaEventDaily.statDate.loe(startDate),
+                        gaEventDaily.statDate.goe(endDate)
+                )
+                .groupBy(gaEventDaily.source)
+                .orderBy(sumEventCount.desc())
+                .limit(7)
+                .fetch();
 
-            if (row != null) {
-                String topSource = row.get(gaEventDaily.source);
-                Long count = row.get(sumEventCount);
+        results.addAll(rows.stream()
+                .map(t -> new ChartResponse(
+                        t.get(gaEventDaily.source),                 // xLabels
+                        String.valueOf(t.get(sumEventCount))        // value
+                ))
+                .toList());
 
-                results.add(new ChartResponse(
-                        startOfMonth.format(ymFmt),          // xLabels = 해당 월 (yyyy-MM)
-                        topSource        // value = 소스명
-                ));
+        if (results.size() < 7) {
+            int emptySize = 7 - results.size();
+            for (int i = 1; i <= emptySize; i++) {
+                results.add(new ChartResponse(null, null));
+            }
+        } else if (ObjectUtils.isEmpty(results)) {
+            for (int i = 1; i <= 7; i++) {
+                results.add(new ChartResponse(null, null));
             }
         }
 
-        // 과거→현재 순으로 정렬
-        return results.stream()
-                .sorted(Comparator.comparing(ChartResponse::getXLabels))
-                .toList();
+
+        return results;
     }
 
     @Override

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/repository/GaUserStatRepositoryImpl.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/repository/GaUserStatRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.roome.admin.roomeadminbe.domain.ga4.dto.response.ChartResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -23,7 +24,7 @@ public class GaUserStatRepositoryImpl implements GaUserStatRepositoryCustom {
                 .select(gaUserStat.mau.sum().coalesce(0L))
                 .from(gaUserStat)
                 .where(
-                        gaUserStat.statDate.eq(LocalDate.now())
+                        gaUserStat.statDate.eq(LocalDate.now().minusDays(1))
                 )
                 .fetchOne();
 
@@ -36,7 +37,7 @@ public class GaUserStatRepositoryImpl implements GaUserStatRepositoryCustom {
                 .select(gaUserStat.mau.sum().coalesce(0L))
                 .from(gaUserStat)
                 .where(
-                        gaUserStat.statDate.eq(LocalDate.now())
+                        gaUserStat.statDate.eq(LocalDate.now().minusDays(1))
                 )
                 .fetchOne();
         today = today == null ? 0L : today;
@@ -45,7 +46,7 @@ public class GaUserStatRepositoryImpl implements GaUserStatRepositoryCustom {
                 .select(gaUserStat.mau.sum().coalesce(0L))
                 .from(gaUserStat)
                 .where(
-                        gaUserStat.statDate.eq(LocalDate.now().minusMonths(1))
+                        gaUserStat.statDate.eq(LocalDate.now().minusMonths(2))
                 )
                 .fetchOne();
 
@@ -62,7 +63,7 @@ public class GaUserStatRepositoryImpl implements GaUserStatRepositoryCustom {
                 .select(gaUserStat.dau.sum().coalesce(0L))
                 .from(gaUserStat)
                 .where(
-                        gaUserStat.statDate.eq(LocalDate.now()) // 오늘 날짜
+                        gaUserStat.statDate.eq(LocalDate.now().minusDays(1)) // 오늘 날짜
                 )
                 .fetchOne();
 
@@ -76,7 +77,7 @@ public class GaUserStatRepositoryImpl implements GaUserStatRepositoryCustom {
                 .select(gaUserStat.dau.sum().coalesce(0L))
                 .from(gaUserStat)
                 .where(
-                        gaUserStat.statDate.eq(LocalDate.now()) // 오늘 날짜
+                        gaUserStat.statDate.eq(LocalDate.now().minusDays(1)) // 오늘 날짜
                 )
                 .fetchOne();
 
@@ -86,7 +87,7 @@ public class GaUserStatRepositoryImpl implements GaUserStatRepositoryCustom {
                 .select(gaUserStat.dau.sum().coalesce(0L))
                 .from(gaUserStat)
                 .where(
-                        gaUserStat.statDate.eq(LocalDate.now().minusDays(1)) // 어제 날짜
+                        gaUserStat.statDate.eq(LocalDate.now().minusDays(2)) // 어제 날짜
                 )
                 .fetchOne();
 
@@ -99,66 +100,88 @@ public class GaUserStatRepositoryImpl implements GaUserStatRepositoryCustom {
 
     @Override
     public List<ChartResponse> getMauChart() {
+        List<ChartResponse> result = new ArrayList<>();
         LocalDate today = LocalDate.now();
 
         // 오늘 ~ 6개월 전까지(총 7개) 대상 일자 생성
-        List<LocalDate> targets = new ArrayList<>();
         for (int i = 0; i <= 6; i++) {
-            targets.add(today.minusMonths(i));
+            List<LocalDate> targets = new ArrayList<>();
+            targets.add(today.minusDays(1).minusMonths(i));
+            NumberExpression<Long> sumEventCount = gaUserStat.mau.sum();
+
+            List<Tuple> rows = jpaQueryFactory
+                    .select(gaUserStat.statDate, sumEventCount)
+                    .from(gaUserStat)
+                    .where(
+                            gaUserStat.statDate.in(targets)
+                    )
+                    .groupBy(gaUserStat.statDate)
+                    .orderBy(gaUserStat.statDate.asc())
+                    .fetch();
+
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+            List<ChartResponse> oneRow =  rows.stream()
+                    .map(t -> new ChartResponse(
+                            t.get(gaUserStat.statDate).format(fmt),                // xLabels
+                            String.valueOf(t.get(sumEventCount))                     // value
+                    ))
+                    .toList();
+
+            if(ObjectUtils.isEmpty(oneRow)){
+                result.add(new ChartResponse(today.minusDays(1).minusMonths(i).format(fmt)
+                        , String.valueOf(0)));
+            }else{
+                result.addAll(oneRow);
+            }
+
         }
+        return result;
+
 
         // SUM(event_count) 별칭을 잡아두면 Tuple에서 안전하게 꺼낼 수 있어요
-        NumberExpression<Long> sumEventCount = gaUserStat.mau.sum();
-
-        List<Tuple> rows = jpaQueryFactory
-                .select(gaUserStat.statDate, sumEventCount)
-                .from(gaUserStat)
-                .where(
-                        gaUserStat.statDate.in(targets)
-                )
-                .groupBy(gaUserStat.statDate)
-                .orderBy(gaUserStat.statDate.asc())
-                .fetch();
-
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-        return rows.stream()
-                .map(t -> new ChartResponse(
-                        t.get(gaUserStat.statDate).format(fmt),                // xLabels
-                        String.valueOf(t.get(sumEventCount))                     // value
-                ))
-                .toList();
     }
 
     @Override
     public List<ChartResponse> getDauChart() {
+        List<ChartResponse> result = new ArrayList<>();
         LocalDate today = LocalDate.now();
 
         // 오늘 ~ 6일 전까지 날짜 리스트 만들기
-        List<LocalDate> targets = new ArrayList<>();
-        for (int i = 0; i <= 6; i++) {
+        for (int i = 1; i <= 7; i++) {
+            List<LocalDate> targets = new ArrayList<>();
             targets.add(today.minusDays(i));
+
+            NumberExpression<Long> sumEventCount = gaUserStat.dau.sum();
+
+            List<Tuple> rows = jpaQueryFactory
+                    .select(gaUserStat.statDate, sumEventCount)
+                    .from(gaUserStat)
+                    .where(
+                            gaUserStat.statDate.in(targets)
+                    )
+                    .groupBy(gaUserStat.statDate)
+                    .orderBy(gaUserStat.statDate.asc())
+                    .fetch();
+
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+            List<ChartResponse> oneRow =  rows.stream()
+                    .map(t -> new ChartResponse(
+                            t.get(gaUserStat.statDate).format(fmt),   // xLabels
+                            String.valueOf(t.get(sumEventCount))        // value
+                    ))
+                    .toList();
+
+            if(ObjectUtils.isEmpty(oneRow)){
+                result.add(new ChartResponse(today.minusDays(i).format(fmt)
+                        , String.valueOf(0)));
+            }else{
+                result.addAll(oneRow);
+            }
+
+
         }
-
-        NumberExpression<Long> sumEventCount = gaUserStat.dau.sum();
-
-        List<Tuple> rows = jpaQueryFactory
-                .select(gaUserStat.statDate, sumEventCount)
-                .from(gaUserStat)
-                .where(
-                        gaUserStat.statDate.in(targets)
-                )
-                .groupBy(gaUserStat.statDate)
-                .orderBy(gaUserStat.statDate.asc())
-                .fetch();
-
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-        return rows.stream()
-                .map(t -> new ChartResponse(
-                        t.get(gaUserStat.statDate).format(fmt),   // xLabels
-                        String.valueOf(t.get(sumEventCount))        // value
-                ))
-                .toList();
+        return result;
     }
 }

--- a/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/service/GaService.java
+++ b/src/main/java/com/roome/admin/roomeadminbe/domain/ga4/service/GaService.java
@@ -93,9 +93,9 @@ public class GaService {
 
     public AiSummaryResponse getAiSummary(){
         AiSummaryResponse aiSummaryResponse = new AiSummaryResponse();
-        aiSummaryResponse.setMostUsedFeature("가장 많이 사용한 기능은 "+gaFeatureStatRepository.getMostUsedFeature()+" 입니다.");
-        aiSummaryResponse.setMostDroppedFeature("가장 이탈률이 많은 기능은 "+gaFeatureStatRepository.getMostDroppedFeature()+" 입니다.");
-        aiSummaryResponse.setMostEntryPath(gaEventDailyRepository.getMostEntryPath()+" 경로에서 가장 많은 사용자가 유입되었습니다.");
+        aiSummaryResponse.setMostUsedFeature(gaFeatureStatRepository.getMostUsedFeature());
+        aiSummaryResponse.setMostDroppedFeature(gaFeatureStatRepository.getMostDroppedFeature());
+        aiSummaryResponse.setMostEntryPath(gaEventDailyRepository.getMostEntryPath());
         return aiSummaryResponse;
     }
 


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명

해당 PR에서 수행한 작업을 간단히 설명해주세요.

### 🏗 작업 내용

- [x] 서비스 사용 지표 카드 인덱스 조회 API 수정
    - MAU, DAU, 신규 사용자의 경우 오늘 data > 어제 데이터 기준으로 조회되게끔 수정
- [x] 서비스 사용 지표 차트 조회 API 수정
    - Response Data에 부족한 데이터가 있더라도 7개 고정되어 들어오게끔 수정
    - 유입경로 차트 API xLabels에는 경로의 이름, value에는 7일치 총 합(count)가 들어오게끔 수정
    - 현재 1개월 count의 총 1위만 6개월치 전송되게 구현되어있음
- [x] 서비스 사용 지표 요약 조회 API 수정
    - value에 값만 들어오게끔 수정(텍스트 제거)

### 📸 테스트 결과 (선택)
<img width="1251" height="998" alt="image" src="https://github.com/user-attachments/assets/c3ae6b61-759d-4357-857a-0aa3ada22275" />


### 🔗 관련 이슈 (선택)
close #48 

### 🚨 참고 사항 (선택)
.
